### PR TITLE
Support asserts in templates and saved traces

### DIFF
--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -196,10 +196,11 @@ main = withSocketsDo $ do
                              (prop socA socB alive onFail archDesc (timeoutDelay flags) (verbosity > 1) (return tc))
   let check_mcause_on_trap tc traceA traceB =
         if or (map rvfiIsTrap traceA) || or (map rvfiIsTrap traceB)
-           then tc <> TC [TS False [encode csrrs 0x342 0 1, encode csrrs 0x343 0 1, encode csrrs 0xbc0 0 1]]
+           then tc <> TC ([TS False [encode csrrs 0x342 0 1, encode csrrs 0x343 0 1, encode csrrs 0xbc0 0 1]], const [])
            else tc
   let saveOnFail tc tcTrans = do
-        let insts = (map diiInstruction $ fromTestCase tc) ++ [diiEnd]
+        let (rawInsts, assert) = fromTestCase tc
+        let insts = (map diiInstruction rawInsts) ++ [diiEnd]
         m_traces <- doRVFIDII socA socB alive (timeoutDelay flags) False insts
         let (traceA, traceB) = fromMaybe (error "unexpected doRVFIDII failure")
                                          m_traces

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -196,10 +196,10 @@ main = withSocketsDo $ do
                              (prop socA socB alive onFail archDesc (timeoutDelay flags) (verbosity > 1) (return tc))
   let check_mcause_on_trap tc traceA traceB =
         if or (map rvfiIsTrap traceA) || or (map rvfiIsTrap traceB)
-           then tc <> TC ([TS False [encode csrrs 0x342 0 1, encode csrrs 0x343 0 1, encode csrrs 0xbc0 0 1]], const [])
+           then tc <> TC (const []) [TS False [encode csrrs 0x342 0 1, encode csrrs 0x343 0 1, encode csrrs 0xbc0 0 1]]
            else tc
   let saveOnFail tc tcTrans = do
-        let (rawInsts, assert) = fromTestCase tc
+        let (rawInsts, _) = fromTestCase tc
         let insts = (map diiInstruction rawInsts) ++ [diiEnd]
         m_traces <- doRVFIDII socA socB alive (timeoutDelay flags) False insts
         let (traceA, traceB) = fromMaybe (error "unexpected doRVFIDII failure")

--- a/src/QuickCheckVEngine/MainHelpers.hs
+++ b/src/QuickCheckVEngine/MainHelpers.hs
@@ -113,7 +113,8 @@ prop scktA scktB alive onFail arch delay doLog gen =
   forAllShrink gen shrink mkProp
   where mkProp testCase = whenFail (onFail testCase) (doProp testCase)
         doProp testCase = monadicIO $ run $ do
-          let instTrace = map diiInstruction $ fromTestCase testCase
+          let (rawInsts, asserts) = fromTestCase testCase
+          let instTrace = map diiInstruction rawInsts
           let insts = instTrace ++ [diiEnd]
           currentlyAlive <- readIORef alive
           if currentlyAlive then do
@@ -124,7 +125,11 @@ prop scktA scktB alive onFail arch delay doLog gen =
                                           (rvfiCheckAndShow $ has_xlen_64 arch)
                                           traceA traceB
                 when doLog $ mapM_ (putStrLn . snd) diff
-                return $ property $ and (map fst diff)
+                let implAAsserts = asserts (init traceA)
+                mapM (\s -> putStrLn ("Impl A failed assert: " ++ s)) implAAsserts
+                let implBAsserts = asserts (init traceB)
+                mapM (\s -> putStrLn ("Impl B failed assert: " ++ s)) implBAsserts
+                return $ property $ (and (map fst diff)) && (null implAAsserts) && (null implBAsserts)
               _ -> return $ property False
           -- We don't want to shrink once one of the implementations has died,
           -- so always return that the property is true

--- a/src/QuickCheckVEngine/MainHelpers.hs
+++ b/src/QuickCheckVEngine/MainHelpers.hs
@@ -126,9 +126,9 @@ prop scktA scktB alive onFail arch delay doLog gen =
                                           traceA traceB
                 when doLog $ mapM_ (putStrLn . snd) diff
                 let implAAsserts = asserts (init traceA)
-                mapM (\s -> putStrLn ("Impl A failed assert: " ++ s)) implAAsserts
                 let implBAsserts = asserts (init traceB)
-                mapM (\s -> putStrLn ("Impl B failed assert: " ++ s)) implBAsserts
+                mapM_ (\s -> putStrLn ("Impl A failed assert: " ++ s)) implAAsserts
+                mapM_ (\s -> putStrLn ("Impl B failed assert: " ++ s)) implBAsserts
                 return $ property $ (and (map fst diff)) && (null implAAsserts) && (null implBAsserts)
               _ -> return $ property False
           -- We don't want to shrink once one of the implementations has died,

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -47,8 +47,9 @@
 -}
 
 module QuickCheckVEngine.RVFI_DII.RVFI (
-  RVFI_Packet
+  RVFI_Packet (..)
 , rvfiEmptyHaltPacket
+, rvfiGetFromString
 , rvfiIsHalt
 , rvfiIsTrap
 , rvfiCheck
@@ -112,6 +113,27 @@ data RVFI_Packet = RVFI_Packet {
 -- Modelling of Atomic Memory Operations
 -- Skipping instructions
 }
+
+rvfiGetFromString "valid"     = Just $ toInteger . rvfi_valid
+rvfiGetFromString "order"     = Just $ toInteger . rvfi_order
+rvfiGetFromString "insn"      = Just $ toInteger . rvfi_insn
+rvfiGetFromString "trap"      = Just $ toInteger . rvfi_trap
+rvfiGetFromString "halt"      = Just $ toInteger . rvfi_halt
+rvfiGetFromString "intr"      = Just $ toInteger . rvfi_intr
+rvfiGetFromString "rs1_addr"  = Just $ toInteger . rvfi_rs1_addr
+rvfiGetFromString "rs2_addr"  = Just $ toInteger . rvfi_rs2_addr
+rvfiGetFromString "rs1_rdata" = Just $ toInteger . rvfi_rs1_rdata
+rvfiGetFromString "rs2_rdata" = Just $ toInteger . rvfi_rs2_rdata
+rvfiGetFromString "rd_addr"   = Just $ toInteger . rvfi_rd_addr
+rvfiGetFromString "rd_wdata"  = Just $ toInteger . rvfi_rd_wdata
+rvfiGetFromString "pc_rdata"  = Just $ toInteger . rvfi_pc_rdata
+rvfiGetFromString "pc_wdata"  = Just $ toInteger . rvfi_pc_wdata
+rvfiGetFromString "mem_addr"  = Just $ toInteger . rvfi_mem_addr
+rvfiGetFromString "mem_rmask" = Just $ toInteger . rvfi_mem_rmask
+rvfiGetFromString "mem_wmask" = Just $ toInteger . rvfi_mem_wmask
+rvfiGetFromString "mem_rdata" = Just $ toInteger . rvfi_mem_rdata
+rvfiGetFromString "mem_wdata" = Just $ toInteger . rvfi_mem_wdata
+rvfiGetFromString _           = Nothing
 
 instance Binary RVFI_Packet where
   put pkt =    putWord8    (rvfi_intr pkt)

--- a/src/QuickCheckVEngine/Template.hs
+++ b/src/QuickCheckVEngine/Template.hs
@@ -202,7 +202,7 @@ instance ToTestCase [Integer] where
 tp = makeTokenParser $ emptyDef { commentLine   = "#"
                                 , reservedNames = [ ".shrink", ".noshrink"
                                                   , ".4byte", ".2byte"
-                                                  , ".assert", ".equals"] }
+                                                  , ".assert"] }
 partial p = (,) <$> p <*> getInput
 parseTestCase = do
   whiteSpace tp
@@ -224,7 +224,7 @@ parseInst = do
 parseAssert = do
   reserved tp ".assert"
   field <- identifier tp
-  reserved tp ".equals"
+  symbol tp "=="
   val <- natural tp
   str <- stringLiteral tp
   return $ \report -> case rvfiGetFromString field of Nothing -> ["Invalid assert (" ++ str ++ "): field " ++ field ++ " not recognised"]


### PR DESCRIPTION
This needs some tidying up + documenting, but seems to hold up to some makeshift testing.

In templates, there's now the Assert constructor, taking:
- A template to make assertions about
- A function from [RVFI_Report] to Bool that is expected to be true
- A string to print should the assert fail

It is expected the most common use will be around Single instructions, e.g.
`Assert (Single $ encode addi 13 0 5, \[x] -> rvfi_rd_wdata x == 13, "13 must be written back")`

A few deficiencies:
- No indication which instruction caused the assert fail - is it reasonable to expect the string is sufficient? In general, assertions need not cover a single instruction so it might not be clear which to refer to (the last one covered by the assert?)
- Not clear what behaviour to use when truncating the template for genTemplateSized - at this point the assertion is over the entire TestCase, so the only real options are to either erase all assertions or keep them (causing runtime errors if an assertion covers an instruction that's been truncated off). A way around this could be to change the structure of TestCases/TestStrands so the information can be preserved for longer (as per the shrinkable flags in TestStrands).


The assertions can also be parsed from saved trace files. Instructions can be followed by
`.assert [FIELD NAME] .equals [INTEGER LITERAL] "[STRING ON FAIL]"`
For example
`.4byte 0x00d00293 .assert rd_wdata .equals 13 "13 must be written back" # addi x5, x0, 13`

Multiple assertions can be added with multiple .asserts, and the assertions are ANDed together.

It would be interesting to know what further annotations are useful: it's just a question of doing the parsing to add them in given how general the mechanism is. I've put .equals so we can be forward-compatible in case we add other constrains (.less_than?). If we think other combinations of asserts (e.g. Assert A or B) might be useful at some point, it might be worth future-proofing the format for it.