### PR TITLE
Add support for trace version negotiation

### DIFF
--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -183,10 +183,21 @@ main = withSocketsDo $ do
   addrB <- resolve (impBIP flags) (impBPort flags)
   socA <- open "implementation-A" addrA
   socB <- open "implementation-B" addrB
-  sendDIIPacket socA diiEnd
-  _ <- recvRVFITrace socA False
-  sendDIIPacket socB diiEnd
-  _ <- recvRVFITrace socB False
+  sendDIIPacket socA diiVersNegotiate
+  socAPkt <- recvRVFIPacket socA
+  -- FIXME: doesn't work socATraceVersion <- rvfiHaltVersion socAPkt
+  when (not (rvfiIsHalt socAPkt)) $
+    error ("Received unexpected initial packet from implementation A: " ++ show socAPkt)
+  when (optVerbosity flags > 1) $
+    putStrLn ("Received initial packet from implementation A: " ++ show socAPkt)
+  let socATraceVer = rvfiHaltVersion socAPkt
+  sendDIIPacket socB diiVersNegotiate
+  socBPkt <- recvRVFIPacket socB
+  when (not (rvfiIsHalt socBPkt)) $
+    error ("Received unexpected initial packet from implementation B: " ++ show socBPkt)
+  when (optVerbosity flags > 1) $
+    putStrLn ("Received initial packet from implementation B: " ++ show socBPkt)
+  let socBTraceVer = rvfiHaltVersion socBPkt
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr
   --
@@ -360,4 +371,5 @@ main = withSocketsDo $ do
         putStrLn ("connecting to " ++ dest ++ " ...")
         sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock (addrAddress addr)
+        putStrLn ("connected to " ++ dest ++ " ...")
         return sock

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -49,6 +49,7 @@ module QuickCheckVEngine.RVFI_DII.DII (
   DII_Packet
 , diiInstruction
 , diiEnd
+, diiVersNegotiate
 ) where
 
 import Data.Word
@@ -115,3 +116,9 @@ diiEnd :: DII_Packet
 diiEnd = DII_Packet { dii_cmd  = dii_cmd_end
                     , dii_time = 1
                     , dii_insn = 0 }
+
+-- | Construct a version negotiation 'DII_Packet'
+diiVersNegotiate :: DII_Packet
+diiVersNegotiate = DII_Packet { dii_cmd  = dii_cmd_end
+                    , dii_time = 1
+                    , dii_insn = 0x56455253 } -- send 'V' 'E' 'R' 'S'

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -50,6 +50,7 @@ module QuickCheckVEngine.RVFI_DII.RVFI (
   RVFI_Packet
 , rvfiEmptyHaltPacket
 , rvfiIsHalt
+, rvfiHaltVersion
 , rvfiIsTrap
 , rvfiCheck
 , rvfiCheckAndShow
@@ -180,7 +181,7 @@ rvfiEmptyHaltPacket = (runGet get (BS.repeat 0)) { rvfi_halt = 1 }
 
 instance Show RVFI_Packet where
   show tok
-    | rvfiIsHalt tok = "halt token"
+    | rvfiIsHalt tok = printf "halt token v%d" (rvfiHaltVersion tok)
     | otherwise = printf "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x (%s)"
                   (show $ rvfi_trap tok /= 0) -- Trap
                   (rvfi_pc_wdata tok)    -- PCWD
@@ -194,6 +195,10 @@ instance Show RVFI_Packet where
 -- | Return 'True' for halt 'RVFI_Packet's
 rvfiIsHalt :: RVFI_Packet -> Bool
 rvfiIsHalt x = rvfi_halt x /= 0
+
+-- | Return 'True' for halt 'RVFI_Packet's
+rvfiHaltVersion :: RVFI_Packet -> Word8
+rvfiHaltVersion x = (shiftR (rvfi_halt x) 1) + 1
 
 -- | Return 'True' for trap 'RVFI_Packet's
 rvfiIsTrap :: RVFI_Packet -> Bool


### PR DESCRIPTION
We send ASCII 'VERS' as the insn field in the initial reset field to indicate
that this is a version negotiation packet. We then use the high bits of
the initial packet's rvfi_halt field as an indicator of the version:
(halt >> 1) + 1, so unchanged implementations will report version 1
support whereas newer implementations can send a value of '3' to indicate
that they support version 2.