### PR TITLE
V2 trace wire format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist-newstyle
 /.stack-work/
 /QCVEngine.iml
+/out/

--- a/QCVEngine.cabal
+++ b/QCVEngine.cabal
@@ -58,5 +58,5 @@ executable QCVEngine
   build-depends:       base >=4.9, time, split >=0.2, regex-posix >=0.95,
                        binary >=0.8, bitwise >=1.0, network >=2.8, parsec,
                        bytestring >=0.10, filemanip >=0.3,
-                       QuickCheck >= 2.12 && < 2.13
+                       basement >= 0.0.10, QuickCheck >= 2.12 && < 2.13
   default-language:    Haskell2010

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -186,8 +186,8 @@ main = withSocketsDo $ do
   socB <- open "implementation-B" addrB
   socATraceVer <- rvfiNegotiateVersion socA "implementation A" (optVerbosity flags)
   socBTraceVer <- rvfiNegotiateVersion socB "implementation B" (optVerbosity flags)
-  let connectionA = (socA, fromIntegral socATraceVer, "implementation A", (optVerbosity flags))
-  let connectionB = (socB, fromIntegral socBTraceVer, "implementation B", (optVerbosity flags))
+  let connectionA = (socA, socATraceVer, "implementation A", (optVerbosity flags))
+  let connectionB = (socB, socBTraceVer, "implementation B", (optVerbosity flags))
 
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -186,8 +186,8 @@ main = withSocketsDo $ do
   socB <- open "implementation-B" addrB
   socATraceVer <- rvfiNegotiateVersion socA "implementation A" (optVerbosity flags)
   socBTraceVer <- rvfiNegotiateVersion socB "implementation B" (optVerbosity flags)
-  let connectionA = (socA, fromIntegral socATraceVer)
-  let connectionB = (socB, fromIntegral socBTraceVer)
+  let connectionA = (socA, fromIntegral socATraceVer, "implementation A", (optVerbosity flags))
+  let connectionB = (socB, fromIntegral socBTraceVer, "implementation B", (optVerbosity flags))
 
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -184,21 +184,9 @@ main = withSocketsDo $ do
   addrB <- resolve (impBIP flags) (impBPort flags)
   socA <- open "implementation-A" addrA
   socB <- open "implementation-B" addrB
-  sendDIIPacket socA diiVersNegotiate
-  socAPkt <- recvRVFIPacket socA
-  -- FIXME: doesn't work socATraceVersion <- rvfiHaltVersion socAPkt
-  when (not (rvfiIsHalt socAPkt)) $
-    error ("Received unexpected initial packet from implementation A: " ++ show socAPkt)
-  when (optVerbosity flags > 1) $
-    putStrLn ("Received initial packet from implementation A: " ++ show socAPkt)
-  let socATraceVer = rvfiHaltVersion socAPkt
-  sendDIIPacket socB diiVersNegotiate
-  socBPkt <- recvRVFIPacket socB
-  when (not (rvfiIsHalt socBPkt)) $
-    error ("Received unexpected initial packet from implementation B: " ++ show socBPkt)
-  when (optVerbosity flags > 1) $
-    putStrLn ("Received initial packet from implementation B: " ++ show socBPkt)
-  let socBTraceVer = rvfiHaltVersion socBPkt
+  socATraceVer <- rvfiNegotiateVersion socA "implementation A" (optVerbosity flags)
+  socBTraceVer <- rvfiNegotiateVersion socB "implementation B" (optVerbosity flags)
+
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr
   --

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -190,7 +190,6 @@ main = withSocketsDo $ do
   let connA = RvfiDiiConnection socA socATraceVer "implementation A" (optVerbosity flags)
   let connB = RvfiDiiConnection socB socBTraceVer "implementation B" (optVerbosity flags)
 
-
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr
   --

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -93,6 +93,7 @@ data Options = Options
     , optSave        :: Bool
     } deriving Show
 
+defaultOptions :: Options
 defaultOptions = Options
     { optVerbosity   = 1
     , nTests         = 100
@@ -176,7 +177,7 @@ main :: IO ()
 main = withSocketsDo $ do
   -- parse command line arguments
   rawArgs <- getArgs
-  (flags, leftover) <- commandOpts rawArgs
+  (flags, _) <- commandOpts rawArgs
   when (optVerbosity flags > 1) $ print flags
   let archDesc = arch flags
   -- initialize model and implementation sockets

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -186,8 +186,9 @@ main = withSocketsDo $ do
   socB <- open "implementation-B" addrB
   socATraceVer <- rvfiNegotiateVersion socA "implementation A" (optVerbosity flags)
   socBTraceVer <- rvfiNegotiateVersion socB "implementation B" (optVerbosity flags)
-  let connectionA = (socA, socATraceVer, "implementation A", (optVerbosity flags))
-  let connectionB = (socB, socBTraceVer, "implementation B", (optVerbosity flags))
+  let connectionA = RvfiDiiConnection socA socATraceVer "implementation A" (optVerbosity flags)
+  let connectionB = RvfiDiiConnection socB socBTraceVer "implementation B" (optVerbosity flags)
+
 
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
   instrSoc <- mapM (open "instruction-generator-port") addrInstr
@@ -366,7 +367,7 @@ main = withSocketsDo $ do
         return addr
     open dest addr = do
         putStrLn ("connecting to " ++ dest ++ " ...")
-        sock <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
+        sock <- Network.Socket.socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
         connect sock (addrAddress addr)
         putStrLn ("connected to " ++ dest ++ " ...")
         return sock

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -211,7 +211,7 @@ main = withSocketsDo $ do
         when (optVerbosity flags > 0) $
           do putStrLn "Replaying shrunk failed test case:"
              let tcNew = tcTrans tc traceA traceB
-             checkSingle tcNew 2 False (testLen flags) (const $ return ())
+             _ <- checkSingle tcNew 2 False (testLen flags) (const $ return ())
              return ()
         when (optSave flags) $
           do case (saveDir flags) of

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -187,8 +187,8 @@ main = withSocketsDo $ do
   socB <- open "implementation-B" addrB
   socATraceVer <- rvfiNegotiateVersion socA "implementation A" (optVerbosity flags)
   socBTraceVer <- rvfiNegotiateVersion socB "implementation B" (optVerbosity flags)
-  let connectionA = RvfiDiiConnection socA socATraceVer "implementation A" (optVerbosity flags)
-  let connectionB = RvfiDiiConnection socB socBTraceVer "implementation B" (optVerbosity flags)
+  let connA = RvfiDiiConnection socA socATraceVer "implementation A" (optVerbosity flags)
+  let connB = RvfiDiiConnection socB socBTraceVer "implementation B" (optVerbosity flags)
 
 
   addrInstr <- mapM (resolve "127.0.0.1") (instrPort flags)
@@ -197,7 +197,7 @@ main = withSocketsDo $ do
   alive <- newIORef True -- Cleared when either implementation times out, since they will may not be able to respond to future queries
   let checkSingle tc verbosity doShrink len onFail = do
         quickCheckWithResult (Args Nothing 1 1 len (verbosity > 0) (if doShrink then 1000 else 0))
-                             (prop connectionA connectionB alive onFail archDesc (timeoutDelay flags) (verbosity > 1) (return tc))
+                             (prop connA connB alive onFail archDesc (timeoutDelay flags) (verbosity > 1) (return tc))
   let check_mcause_on_trap tc traceA traceB =
         if or (map rvfiIsTrap traceA) || or (map rvfiIsTrap traceB)
            then tc <> TC (const []) [TS False [encode csrrs 0x342 0 1, encode csrrs 0x343 0 1, encode csrrs 0xbc0 0 1]]
@@ -205,14 +205,14 @@ main = withSocketsDo $ do
   let saveOnFail tc tcTrans = do
         let (rawInsts, _) = fromTestCase tc
         let insts = (map diiInstruction rawInsts) ++ [diiEnd]
-        m_traces <- doRVFIDII connectionA connectionB alive (timeoutDelay flags) False insts
+        m_traces <- doRVFIDII connA connB alive (timeoutDelay flags) False insts
         let (traceA, traceB) = fromMaybe (error "unexpected doRVFIDII failure")
                                          m_traces
         writeFile "last_failure.S" ("# last failing test case:\n" ++ show tc)
         when (optVerbosity flags > 0) $
           do putStrLn "Replaying shrunk failed test case:"
              let tcNew = tcTrans tc traceA traceB
-             _ <- checkSingle tcNew 2 False (testLen flags) (const $ return ())
+             checkSingle tcNew 2 False (testLen flags) (const $ return ())
              return ()
         when (optSave flags) $
           do case (saveDir flags) of
@@ -235,7 +235,7 @@ main = withSocketsDo $ do
                     else quickCheckWithResult
   let checkGen gen remainingTests = do
         res <- checkResult (Args Nothing remainingTests 1 (testLen flags) (optVerbosity flags > 0) (if optShrink flags then 1000 else 0))
-                           (prop connectionA connectionB alive checkTrapAndSave archDesc (timeoutDelay flags) (optVerbosity flags > 1) gen)
+                           (prop connA connB alive checkTrapAndSave archDesc (timeoutDelay flags) (optVerbosity flags > 1) gen)
         case res of Failure {} -> return 1
                     _          -> return 0
   let checkFile (memoryInitFile :: Maybe FilePath) (skipped :: Int) (fileName :: FilePath)

--- a/src/QuickCheckVEngine/MainHelpers.hs
+++ b/src/QuickCheckVEngine/MainHelpers.hs
@@ -58,7 +58,7 @@ import Network.Socket.ByteString.Lazy
 import Test.QuickCheck
 import Test.QuickCheck.Monadic
 import Control.Monad
-import Control.Exception
+import Control.Exception (try, SomeException(..))
 import qualified Data.ByteString.Lazy as BS
 
 import qualified InstrCodec
@@ -106,7 +106,7 @@ zipWithPadding a b f = go
 --   for equivalence. It receives among other things a callback function
 --   'TestCase -> IO ()' to be performed on failure that takes in the reduced
 --   'TestCase' which caused the failure
-prop :: (Socket, Int, String, Int) -> (Socket, Int, String, Int) -> IORef Bool
+prop :: RvfiDiiConnection -> RvfiDiiConnection -> IORef Bool
      -> (TestCase -> IO ()) -> ArchDesc -> Int -> Bool -> Gen TestCase -> Property
 prop connA connB alive onFail arch delay doLog gen =
   forAllShrink gen shrink mkProp
@@ -141,7 +141,7 @@ prop connA connB alive onFail arch delay doLog gen =
 --   'Just (traceA, traceB)', otherwise 'Nothing' and sets the provided
 --   'IORef Bool' for alive to 'False' indicating that further interaction with
 --   the implementations is futile
-doRVFIDII :: (Socket, Int, String, Int) -> (Socket, Int, String, Int) -> IORef Bool -> Int -> Bool -> [DII_Packet]
+doRVFIDII :: RvfiDiiConnection -> RvfiDiiConnection -> IORef Bool -> Int -> Bool -> [DII_Packet]
           -> IO (Maybe ([RVFI_Packet], [RVFI_Packet]))
 doRVFIDII connA connB alive delay doLog insts = do
   currentlyAlive <- readIORef alive

--- a/src/QuickCheckVEngine/MainHelpers.hs
+++ b/src/QuickCheckVEngine/MainHelpers.hs
@@ -168,7 +168,7 @@ doRVFIDII connA connB alive delay doLog insts = do
         return Nothing
       Left (SomeException e) -> do
         writeIORef alive False
-        putStrLn ("Error: exception on IO with implementations. Forcing all future tests to report 'SUCCESS'" ++ show e)
+        putStrLn ("Error: exception on IO with implementations. Forcing all future tests to report 'SUCCESS': " ++ show e)
         return Nothing
   else do
      putStrLn "Warning: doRVFIDII called when both implementations are not alive"

--- a/src/QuickCheckVEngine/RVFI_DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII.hs
@@ -45,16 +45,15 @@
 --    This module re-exports the 'QuickCheckVEngine.RVFI_DII.RVFI' and
 --    'QuickCheckVEngine.RVFI_DII.DII' modules, and provides functions to send and
 --    receive 'DII_Packet's and 'RVFI_Packet's over a 'Socket'.
-module QuickCheckVEngine.RVFI_DII
-  ( module QuickCheckVEngine.RVFI_DII.RVFI,
-    module QuickCheckVEngine.RVFI_DII.DII,
-    RvfiDiiConnection(..),
-    sendDIIPacket,
-    sendDIITrace,
-    recvRVFITrace,
-    rvfiNegotiateVersion,
-  )
-where
+module QuickCheckVEngine.RVFI_DII (
+  module QuickCheckVEngine.RVFI_DII.RVFI
+, module QuickCheckVEngine.RVFI_DII.DII
+, RvfiDiiConnection(..)
+, sendDIIPacket
+, sendDIITrace
+, recvRVFITrace
+, rvfiNegotiateVersion
+) where
 
 import Control.Monad
 import Data.Binary

--- a/src/QuickCheckVEngine/RVFI_DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII.hs
@@ -65,7 +65,7 @@ import Network.Socket.ByteString.Lazy
 import QuickCheckVEngine.RVFI_DII.DII
 import QuickCheckVEngine.RVFI_DII.RVFI
 
-data RvfiDiiConnection = RvfiDiiConnection Socket Int String Int
+data RvfiDiiConnection = RvfiDiiConnection Socket Int String
 
 -- | Send a single 'DII_Packet'
 sendDIIPacket :: Socket -> DII_Packet -> IO ()
@@ -73,23 +73,23 @@ sendDIIPacket sckt inst = sendAll sckt $ BS.reverse (encode inst)
 
 -- | Send an instruction trace (a '[DII_Packet]')
 sendDIITrace :: RvfiDiiConnection -> [DII_Packet] -> IO ()
-sendDIITrace (RvfiDiiConnection sckt _ _ _) trace = mapM_ (sendDIIPacket sckt) trace
+sendDIITrace (RvfiDiiConnection sckt _ _) trace = mapM_ (sendDIIPacket sckt) trace
 
 -- | Receive a single 'RVFI_Packet'
-recvRVFIPacket :: RvfiDiiConnection -> IO RVFI_Packet
-recvRVFIPacket (RvfiDiiConnection sock 1 name verbosity) = rvfiReadV1Response ((recvBlking sock), name, verbosity)
-recvRVFIPacket (RvfiDiiConnection sock 2 name verbosity) = rvfiReadV2Response ((recvBlking sock), name, verbosity)
-recvRVFIPacket (RvfiDiiConnection _ vers name _) = error (name ++ " invalid trace version" ++ show vers)
+recvRVFIPacket :: RvfiDiiConnection -> Int -> IO RVFI_Packet
+recvRVFIPacket (RvfiDiiConnection sock 1 name) verbosity = rvfiReadV1Response ((recvBlking sock), name, verbosity)
+recvRVFIPacket (RvfiDiiConnection sock 2 name) verbosity = rvfiReadV2Response ((recvBlking sock), name, verbosity)
+recvRVFIPacket (RvfiDiiConnection _ vers name) _ = error (name ++ " invalid trace version" ++ show vers)
 
 -- | Receive an execution trace (a '[RVFI_Packet]')
-recvRVFITrace :: RvfiDiiConnection -> Bool -> IO [RVFI_Packet]
-recvRVFITrace conn doLog = do
-  rvfiPkt <- recvRVFIPacket conn
-  when doLog $ putStrLn $ "\t" ++ show rvfiPkt
+recvRVFITrace :: RvfiDiiConnection -> Int -> IO [RVFI_Packet]
+recvRVFITrace conn verbosity = do
+  rvfiPkt <- recvRVFIPacket conn verbosity
+  when (verbosity > 1) $ putStrLn $ "\t" ++ show rvfiPkt
   if rvfiIsHalt rvfiPkt
     then return [rvfiPkt]
     else do
-      morePkts <- recvRVFITrace conn doLog
+      morePkts <- recvRVFITrace conn verbosity
       return (rvfiPkt : morePkts)
 
 -- | Perform a trace version negotiation with an implementation and return the

--- a/src/QuickCheckVEngine/RVFI_DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII.hs
@@ -77,6 +77,7 @@ sendDIITrace (sckt, _, _, _) trace = mapM_ (sendDIIPacket sckt) trace
 -- | Receive a single 'RVFI_Packet'
 recvRVFIPacket :: (Socket, Int) -> (String, Int) -> IO RVFI_Packet
 recvRVFIPacket (sock, 1) (name, verbosity) = rvfiReadV1Response ((recvBlking sock), name, verbosity)
+recvRVFIPacket (sock, 2) (name, verbosity) = rvfiReadV2Response ((recvBlking sock), name, verbosity)
 recvRVFIPacket (_, vers) (name, _) = error (name ++ " invalid trace version" ++ show vers)
 
 -- | Receive an execution trace (a '[RVFI_Packet]')

--- a/src/QuickCheckVEngine/RVFI_DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII.hs
@@ -59,19 +59,13 @@ import Control.Monad
 import Data.Binary
 import Data.Binary.Get
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.ByteString.Lazy.Char8 as C8
 import Data.Int
 import Network.Socket
 import Network.Socket.ByteString.Lazy
 import QuickCheckVEngine.RVFI_DII.DII
 import QuickCheckVEngine.RVFI_DII.RVFI
 
-data RvfiDiiConnection = RvfiDiiConnection
-  { socket :: Socket,
-    traceVersion :: Int,
-    name :: String,
-    verbosity :: Int
-  }
+data RvfiDiiConnection = RvfiDiiConnection Socket Int String Int
 
 -- | Send a single 'DII_Packet'
 sendDIIPacket :: Socket -> DII_Packet -> IO ()

--- a/src/QuickCheckVEngine/RVFI_DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII.hs
@@ -117,6 +117,9 @@ rvfiNegotiateVersion sckt name verbosity = do
                ++ ": got " ++ show magic ++ " but expected \"version=\"")
       let ver = runGet Data.Binary.Get.getInt64le acceptedVer
       putStrLn ("Received " ++ name ++ " set-version ack for version " ++ show ver)
+      when (fromIntegral ver /= supportedVer) $
+        error ("Received version response with unexpected version from " ++ name
+               ++ ": got " ++ show ver ++ " but expected 2.")
   when (supportedVer /= 2) $
     putStrLn ("WARNING: " ++ name ++ " does not support version 2 traces.")
   return supportedVer

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -124,6 +124,12 @@ diiEnd = DII_Packet { dii_cmd  = dii_cmd_end
                     , dii_insn = 0 }
 
 -- | Construct a version negotiation 'DII_Packet'
+--   A version negotiation packet uses a 'dii_cmd_end' command with embedded
+--   metadata to guarantee that implementations that only support the version 1
+--   trace format continue to work unmodified. This is useful to avoid having
+--   to update legacy implementations and to support conmparing new versions
+--   of an implementation against an older version that does not yet include
+--   support for version 2 traces.
 diiVersNegotiate :: DII_Packet
 diiVersNegotiate = DII_Packet { dii_cmd  = dii_cmd_end
                               , dii_time = 1

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -74,6 +74,10 @@ dii_cmd_instruction = 1
 dii_cmd_end :: DII_Cmd
 dii_cmd_end = 0
 
+-- | A set-version command
+dii_cmd_set_version :: DII_Cmd
+dii_cmd_set_version = 0x76 -- 'v'
+
 -- | The 'DII_Packet' type captures the DII interface as defined in
 --   https://github.com/CTSRD-CHERI/TestRIG/blob/master/RVFI-DII.md
 data DII_Packet = DII_Packet { -- | the command (instruction/end packet)
@@ -122,11 +126,11 @@ diiEnd = DII_Packet { dii_cmd  = dii_cmd_end
 -- | Construct a version negotiation 'DII_Packet'
 diiVersNegotiate :: DII_Packet
 diiVersNegotiate = DII_Packet { dii_cmd  = dii_cmd_end
-                    , dii_time = 1
-                    , dii_insn = 0x56455253 } -- send 'V' 'E' 'R' 'S'
+                              , dii_time = 1
+                              , dii_insn = 0x56455253 } -- send 'V' 'E' 'R' 'S'
 
 -- | Construct a version request 'DII_Packet'
 diiRequestVers :: Word32 -> DII_Packet
-diiRequestVers vers = DII_Packet { dii_cmd  = 0x76 -- 'v'
-                                  , dii_time = 1
-                                  , dii_insn = vers }
+diiRequestVers vers = DII_Packet { dii_cmd  = dii_cmd_set_version
+                                 , dii_time = 1
+                                 , dii_insn = vers }

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -58,7 +58,6 @@ import Data.Word
 import Data.Binary
 import Data.Binary.Put
 import Data.Binary.Get
-import Data.Semigroup -- Should no longer be required with modern ghc
 
 -- | Type synonym for a DII command
 type DII_Cmd = Word8
@@ -90,7 +89,7 @@ instance Binary DII_Packet where
             <> putWord8 (dii_cmd pkt)
             <> putWord16be (dii_time pkt)
             <> putWord32be (dii_insn pkt)
-  get = do getWord8
+  get = do _ <- getWord8
            cmd  <- getWord8
            time <- getWord16be
            insn <- getWord32be

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -58,6 +58,7 @@ import Data.Word
 import Data.Binary
 import Data.Binary.Put
 import Data.Binary.Get
+import Data.Semigroup -- Should no longer be required with modern ghc
 
 -- | Type synonym for a DII command
 type DII_Cmd = Word8

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -4,6 +4,7 @@
 -- Copyright (c) 2018 Matthew Naylor
 -- Copyright (c) 2018 Jonathan Woodruff
 -- Copyright (c) 2018-2020 Alexandre Joannou
+-- Copyright (c) 2020 Alex Richardson
 -- All rights reserved.
 --
 -- This software was developed by SRI International and the University of

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -49,6 +49,7 @@ module QuickCheckVEngine.RVFI_DII.DII (
   DII_Packet
 , diiInstruction
 , diiEnd
+, diiVersNegotiate
 ) where
 
 import Data.Word
@@ -115,3 +116,9 @@ diiEnd :: DII_Packet
 diiEnd = DII_Packet { dii_cmd  = dii_cmd_end
                     , dii_time = 1
                     , dii_insn = 0 }
+
+-- | Construct a version negotiation 'DII_Packet'
+diiVersNegotiate :: DII_Packet
+diiVersNegotiate = DII_Packet { dii_cmd  = dii_cmd_end
+                    , dii_time = 1
+                    , dii_insn = 0x56455253 } -- send 'V' 'E' 'R' 'S'

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -50,6 +50,7 @@ module QuickCheckVEngine.RVFI_DII.DII (
 , diiInstruction
 , diiEnd
 , diiVersNegotiate
+, diiRequestVers
 ) where
 
 import Data.Word
@@ -122,3 +123,9 @@ diiVersNegotiate :: DII_Packet
 diiVersNegotiate = DII_Packet { dii_cmd  = dii_cmd_end
                     , dii_time = 1
                     , dii_insn = 0x56455253 } -- send 'V' 'E' 'R' 'S'
+
+-- | Construct a version request 'DII_Packet'
+diiRequestVers :: Word32 -> DII_Packet
+diiRequestVers vers = DII_Packet { dii_cmd  = 0x76 -- 'v'
+                                  , dii_time = 1
+                                  , dii_insn = vers }

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -405,6 +405,7 @@ ixlString :: Maybe RV_XL -> String
 ixlString Nothing = "?"
 ixlString (Just 1) = "32"
 ixlString (Just 2) = "64"
+ixlString (Just 3) = "128"
 ixlString (Just _) = "Invalid"
 
 instance Show RVFI_Packet where

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -58,6 +58,7 @@ module QuickCheckVEngine.RVFI_DII.RVFI
     rvfiReadDataPacketWithMagic,
     rvfiReadV1Response,
     rvfiReadV2Response,
+    rvfi_rd_wdata_or_zero,
   )
 where
 
@@ -122,20 +123,23 @@ rvfiGetFromString "insn"      = Just $ toInteger . rvfi_insn
 rvfiGetFromString "trap"      = Just $ toInteger . rvfi_trap
 rvfiGetFromString "halt"      = Just $ toInteger . rvfi_halt
 rvfiGetFromString "intr"      = Just $ toInteger . rvfi_intr
-rvfiGetFromString "rs1_addr"  = Just $ toInteger . rvfi_rs1_addr
-rvfiGetFromString "rs2_addr"  = Just $ toInteger . rvfi_rs2_addr
-rvfiGetFromString "rs1_rdata" = Just $ toInteger . rvfi_rs1_rdata
-rvfiGetFromString "rs2_rdata" = Just $ toInteger . rvfi_rs2_rdata
-rvfiGetFromString "rd_addr"   = Just $ toInteger . rvfi_rd_addr
-rvfiGetFromString "rd_wdata"  = Just $ toInteger . rvfi_rd_wdata
+rvfiGetFromString "rs1_addr"  = Just $ toInteger . rvfi_rs1_addr . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
+rvfiGetFromString "rs2_addr"  = Just $ toInteger . rvfi_rs2_addr . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
+rvfiGetFromString "rs1_rdata" = Just $ toInteger . rvfi_rs1_rdata . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
+rvfiGetFromString "rs2_rdata" = Just $ toInteger . rvfi_rs2_rdata . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
+rvfiGetFromString "rd_addr"   = Just $ toInteger . rvfi_rd_addr . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
+rvfiGetFromString "rd_wdata"  = Just $ toInteger . rvfi_rd_wdata . (fromMaybe rvfiEmptyIntData) . rvfi_int_data
 rvfiGetFromString "pc_rdata"  = Just $ toInteger . rvfi_pc_rdata
 rvfiGetFromString "pc_wdata"  = Just $ toInteger . rvfi_pc_wdata
-rvfiGetFromString "mem_addr"  = Just $ toInteger . rvfi_mem_addr
-rvfiGetFromString "mem_rmask" = Just $ toInteger . rvfi_mem_rmask
-rvfiGetFromString "mem_wmask" = Just $ toInteger . rvfi_mem_wmask
-rvfiGetFromString "mem_rdata" = Just $ toInteger . rvfi_mem_rdata
-rvfiGetFromString "mem_wdata" = Just $ toInteger . rvfi_mem_wdata
+rvfiGetFromString "mem_addr"  = Just $ toInteger . rvfi_mem_addr . (fromMaybe rvfiEmptyMemData) . rvfi_mem_data
+rvfiGetFromString "mem_rmask" = Just $ toInteger . rvfi_mem_rmask . (fromMaybe rvfiEmptyMemData) . rvfi_mem_data
+rvfiGetFromString "mem_wmask" = Just $ toInteger . rvfi_mem_wmask . (fromMaybe rvfiEmptyMemData) . rvfi_mem_data
+rvfiGetFromString "mem_rdata" = Just $ toInteger . toNatural . rvfi_mem_rdata . (fromMaybe rvfiEmptyMemData) . rvfi_mem_data
+rvfiGetFromString "mem_wdata" = Just $ toInteger . toNatural . rvfi_mem_wdata . (fromMaybe rvfiEmptyMemData) . rvfi_mem_data
 rvfiGetFromString _           = Nothing
+
+rvfi_rd_wdata_or_zero :: RVFI_Packet -> Word64
+rvfi_rd_wdata_or_zero x = rvfi_rd_wdata (fromMaybe rvfiEmptyIntData (rvfi_int_data x))
 
 data RVFI_IntData = RVFI_IntData
   { rvfi_rs1_addr :: {-# UNPACK #-} !RV_RegIdx,

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -66,6 +66,7 @@ import Data.Bits
 import Data.Int
 import qualified Data.Bits.Bitwise as BW
 import qualified Data.ByteString.Lazy as BS
+import Data.ByteString.Lazy.Builder (lazyByteStringHex, toLazyByteString)
 import Data.Maybe
 import RISCV
 import Text.Printf
@@ -168,10 +169,14 @@ rvfiEmptyMemData =
       rvfi_mem_wdata = 0
     }
 
-rvfiReadV1Response :: (Int64 -> IO BS.ByteString) -> IO RVFI_Packet
-rvfiReadV1Response reader = do
+hexStr :: BS.ByteString -> String
+hexStr msg = show (toLazyByteString (lazyByteStringHex msg))
+
+rvfiReadV1Response :: (Int64 -> IO BS.ByteString) -> (String, Int) -> IO RVFI_Packet
+rvfiReadV1Response reader (name, verbosity)= do
   msg <- reader 88
-  putStrLn ("Read packet: " ++ show msg)
+  when (verbosity > 1) $
+    putStrLn ("\t" ++ name ++ " read packet: " ++ hexStr msg)
   -- Note: BS.reverse since the decode was written in BE order
   return $ runGet (isolate 88 rvfiDecodeV1Response) (BS.reverse msg)
 

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -403,12 +403,16 @@ rvfiEmptyHaltPacket =
       rvfi_mem_data = Nothing
     }
 
+prvString :: Maybe RV_PrivMode -> String
+prvString Nothing = "PRV_?"
+prvString (Just x) = show x
+
 instance Show RVFI_Packet where
   show tok
     | rvfiIsHalt tok = printf "halt token v%d" (rvfiHaltVersion tok)
     | otherwise =
       printf
-        "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x P:%s (%s)"
+        "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x %s (%s)"
         (show $ rvfi_trap tok /= 0) -- Trap
         (rvfi_pc_wdata tok) -- PCWD
         (rvfi_rd_addr intData) -- RD
@@ -417,7 +421,7 @@ instance Show RVFI_Packet where
         (toNatural (rvfi_mem_wdata memData)) -- MWD
         (rvfi_mem_wmask memData) -- MWM
         (rvfi_insn tok)
-        (show (rvfi_mode tok))
+        (prvString (rvfi_mode tok))
         (pretty (toInteger (rvfi_insn tok))) -- Inst
     where
       intData = fromMaybe rvfiEmptyIntData (rvfi_int_data tok)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -221,7 +221,7 @@ instance Binary RVFI_Packet where
 
 -- | An otherwise empty halt token for padding
 rvfiEmptyHaltPacket :: RVFI_Packet
-rvfiEmptyHaltPacket = (runGet get (BS.repeat 0)) { rvfi_halt = 1 }
+rvfiEmptyHaltPacket = (runGet get (BS.repeat 0)) {rvfi_halt = 1}
 
 instance Show RVFI_Packet where
   show tok
@@ -247,9 +247,9 @@ instance Show RVFI_Packet where
 rvfiIsHalt :: RVFI_Packet -> Bool
 rvfiIsHalt x = rvfi_halt x /= 0
 
--- | Return 'True' for halt 'RVFI_Packet's
+-- | Return the trace version for a halt packet (using the previously-unused bits)
 rvfiHaltVersion :: RVFI_Packet -> Word8
-rvfiHaltVersion x = (shiftR (rvfi_halt x) 1) + 1
+rvfiHaltVersion x = 1 + shiftR (rvfi_halt x) 1
 
 -- | Return 'True' for trap 'RVFI_Packet's
 rvfiIsTrap :: RVFI_Packet -> Bool

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -51,6 +51,7 @@ module QuickCheckVEngine.RVFI_DII.RVFI (
 , rvfiEmptyHaltPacket
 , rvfiGetFromString
 , rvfiIsHalt
+, rvfiHaltVersion
 , rvfiIsTrap
 , rvfiCheck
 , rvfiCheckAndShow
@@ -202,7 +203,7 @@ rvfiEmptyHaltPacket = (runGet get (BS.repeat 0)) { rvfi_halt = 1 }
 
 instance Show RVFI_Packet where
   show tok
-    | rvfiIsHalt tok = "halt token"
+    | rvfiIsHalt tok = printf "halt token v%d" (rvfiHaltVersion tok)
     | otherwise = printf "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x (%s)"
                   (show $ rvfi_trap tok /= 0) -- Trap
                   (rvfi_pc_wdata tok)    -- PCWD
@@ -216,6 +217,10 @@ instance Show RVFI_Packet where
 -- | Return 'True' for halt 'RVFI_Packet's
 rvfiIsHalt :: RVFI_Packet -> Bool
 rvfiIsHalt x = rvfi_halt x /= 0
+
+-- | Return 'True' for halt 'RVFI_Packet's
+rvfiHaltVersion :: RVFI_Packet -> Word8
+rvfiHaltVersion x = (shiftR (rvfi_halt x) 1) + 1
 
 -- | Return 'True' for trap 'RVFI_Packet's
 rvfiIsTrap :: RVFI_Packet -> Bool

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -45,22 +45,22 @@
 --    The 'QuickCheckVEngine.RVFI_DII.RVFI' module defines the RISC-V RVFI
 --    interface as introduced
 --    <https://github.com/SymbioticEDA/riscv-formal/blob/master/docs/rvfi.md here>
-module QuickCheckVEngine.RVFI_DII.RVFI
-  ( RVFI_Packet,
-    rvfiEmptyHaltPacket,
-    rvfiGetFromString,
-    rvfiIsHalt,
-    rvfiHaltVersion,
-    rvfiIsTrap,
-    rvfiCheck,
-    rvfiCheckMagicBytes,
-    rvfiCheckAndShow,
-    rvfiReadDataPacketWithMagic,
-    rvfiReadV1Response,
-    rvfiReadV2Response,
-    rvfi_rd_wdata_or_zero,
-  )
-where
+module QuickCheckVEngine.RVFI_DII.RVFI (
+  RVFI_Packet (..)
+, rvfiEmptyHaltPacket
+, rvfiGetFromString
+, rvfiIsHalt
+, rvfiHaltVersion
+, rvfiIsTrap
+, rvfiCheck
+, rvfiCheckAndShow
+, rvfiCheckMagicBytes
+, rvfiCheckAndShow
+, rvfiReadDataPacketWithMagic
+, rvfiReadV1Response
+, rvfiReadV2Response
+, rvfi_rd_wdata_or_zero
+) where
 
 import Basement.Numerical.Number (toNatural)
 import qualified Basement.Types.Word256
@@ -92,31 +92,31 @@ type RV_XL = Word8
 -- * Definition of the RISC-V Formal Interface
 
 -- | The 'RVFI_Packet' type captures (a subset of) the RISC-V Formal Interface
-data RVFI_Packet = RVFI_Packet
-  { -- Metadata
-    rvfi_valid :: Word8,
-    rvfi_order :: Word64,
-    rvfi_insn :: Word64,
-    rvfi_trap :: Word8,
-    rvfi_halt :: Word8,
-    rvfi_intr :: Word8,
-    rvfi_mode :: Maybe RV_PrivMode,
-    rvfi_ixl :: Maybe RV_XL,
-    -- Program Counter
-    rvfi_pc_rdata :: RV_WordXLEN,
-    rvfi_pc_wdata :: RV_WordXLEN,
-    -- Integer Register Read/Write
-    rvfi_int_data :: Maybe RVFI_IntData,
-    -- Memory Access
-    rvfi_mem_data :: Maybe RVFI_MemAccessData
-    -- Further TODOs in the RVFI specification:
-    -- Control and Status Registers (CSRs)
-    -- Modelling of Floating-Point State
-    -- Handling of Speculative Execution
-    -- Modelling of Virtual Memory
-    -- Modelling of Atomic Memory Operations
-    -- Skipping instructions
-  }
+data RVFI_Packet = RVFI_Packet {
+-- Metadata
+  rvfi_valid :: Word8
+, rvfi_order :: Word64
+, rvfi_insn  :: Word64
+, rvfi_trap  :: Word8
+, rvfi_halt  :: Word8
+, rvfi_intr  :: Word8
+, rvfi_mode  :: Maybe RV_PrivMode
+, rvfi_ixl   :: Maybe RV_XL
+-- Program Counter
+, rvfi_pc_rdata :: RV_WordXLEN
+, rvfi_pc_wdata :: RV_WordXLEN
+-- Integer Register Read/Write
+, rvfi_int_data :: Maybe RVFI_IntData
+-- Memory Access
+, rvfi_mem_data :: Maybe RVFI_MemAccessData
+-- Further TODOs in the RVFI specification:
+-- Control and Status Registers (CSRs)
+-- Modelling of Floating-Point State
+-- Handling of Speculative Execution
+-- Modelling of Virtual Memory
+-- Modelling of Atomic Memory Operations
+-- Skipping instructions
+}
 
 rvfiGetFromString :: [Char] -> Maybe (RVFI_Packet -> Integer)
 rvfiGetFromString "valid"     = Just $ toInteger . rvfi_valid
@@ -143,44 +143,42 @@ rvfiGetFromString _           = Nothing
 rvfi_rd_wdata_or_zero :: RVFI_Packet -> Word64
 rvfi_rd_wdata_or_zero x = rvfi_rd_wdata (fromMaybe rvfiEmptyIntData (rvfi_int_data x))
 
-data RVFI_IntData = RVFI_IntData
-  { rvfi_rs1_addr :: {-# UNPACK #-} !RV_RegIdx,
-    rvfi_rs2_addr :: {-# UNPACK #-} !RV_RegIdx,
-    rvfi_rs1_rdata :: {-# UNPACK #-} !RV_WordXLEN,
-    rvfi_rs2_rdata :: {-# UNPACK #-} !RV_WordXLEN,
-    rvfi_rd_addr :: {-# UNPACK #-} !RV_RegIdx,
-    rvfi_rd_wdata :: {-# UNPACK #-} !RV_WordXLEN
+data RVFI_IntData = RVFI_IntData {
+  rvfi_rs1_addr  :: {-# UNPACK #-} !RV_RegIdx
+, rvfi_rs2_addr  :: {-# UNPACK #-} !RV_RegIdx
+, rvfi_rs1_rdata :: {-# UNPACK #-} !RV_WordXLEN
+, rvfi_rs2_rdata :: {-# UNPACK #-} !RV_WordXLEN
+, rvfi_rd_addr   :: {-# UNPACK #-} !RV_RegIdx
+, rvfi_rd_wdata  :: {-# UNPACK #-} !RV_WordXLEN
   }
   deriving (Show)
 
 rvfiEmptyIntData :: RVFI_IntData
-rvfiEmptyIntData =
-  RVFI_IntData
-    { rvfi_rs1_addr = 0,
-      rvfi_rs2_addr = 0,
-      rvfi_rs1_rdata = 0,
-      rvfi_rs2_rdata = 0,
-      rvfi_rd_addr = 0,
-      rvfi_rd_wdata = 0
-    }
+rvfiEmptyIntData = RVFI_IntData {
+rvfi_rs1_addr = 0
+, rvfi_rs2_addr = 0
+, rvfi_rs1_rdata = 0
+, rvfi_rs2_rdata = 0
+, rvfi_rd_addr = 0
+, rvfi_rd_wdata = 0
+}
 
-data RVFI_MemAccessData = RVFI_MemAccessData
-  { rvfi_mem_addr :: {-# UNPACK #-} !RV_WordXLEN,
-    rvfi_mem_rmask :: {-# UNPACK #-} !Word32,
-    rvfi_mem_wmask :: {-# UNPACK #-} !Word32,
-    rvfi_mem_rdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256,
-    rvfi_mem_wdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256
-  }
+data RVFI_MemAccessData = RVFI_MemAccessData {
+ rvfi_mem_addr   :: {-# UNPACK #-} !RV_WordXLEN
+, rvfi_mem_rmask :: {-# UNPACK #-} !Word32
+, rvfi_mem_wmask :: {-# UNPACK #-} !Word32
+, rvfi_mem_rdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256
+, rvfi_mem_wdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256
+}
 
 rvfiEmptyMemData :: RVFI_MemAccessData
-rvfiEmptyMemData =
-  RVFI_MemAccessData
-    { rvfi_mem_addr = 0,
-      rvfi_mem_rmask = 0,
-      rvfi_mem_wmask = 0,
-      rvfi_mem_rdata = 0,
-      rvfi_mem_wdata = 0
-    }
+rvfiEmptyMemData = RVFI_MemAccessData {
+  rvfi_mem_addr = 0
+, rvfi_mem_rmask = 0
+, rvfi_mem_wmask = 0
+, rvfi_mem_rdata = 0
+, rvfi_mem_wdata = 0
+}
 
 hexStr :: BS.ByteString -> String
 hexStr msg = show (toLazyByteString (lazyByteStringHex msg))
@@ -254,23 +252,20 @@ rvfiDecodeV2Header = do
   pc_rdata <- getWord64le
   pc_wdata <- getWord64le
   availableFeatures <- getWord64le
-  return $
-    ( RVFI_Packet
-        { rvfi_valid = valid,
-          rvfi_order = order,
-          rvfi_insn = insn,
-          rvfi_trap = trap,
-          rvfi_halt = halt,
-          rvfi_intr = intr,
-          rvfi_mode = Just (toEnum (fromIntegral mode)),
-          rvfi_ixl = Just ixl,
-          rvfi_pc_rdata = pc_rdata,
-          rvfi_pc_wdata = pc_wdata,
-          rvfi_int_data = Nothing,
-          rvfi_mem_data = Nothing
-        },
-      availableFeatures
-    )
+  return $ (RVFI_Packet {
+      rvfi_valid = valid
+    , rvfi_order = order
+    , rvfi_insn = insn
+    , rvfi_trap = trap
+    , rvfi_halt = halt
+    , rvfi_intr = intr
+    , rvfi_mode = Just (toEnum (fromIntegral mode))
+    , rvfi_ixl = Just ixl
+    , rvfi_pc_rdata = pc_rdata
+    , rvfi_pc_wdata = pc_wdata
+    , rvfi_int_data = Nothing
+    , rvfi_mem_data = Nothing
+    }, availableFeatures)
 
 -- See sail-riscv/model/rvfi_dii.sail for the bitfield definitions
 rvfiMaybeReadIntData :: (Int64 -> IO BS.ByteString, String, Int) -> RVFIFeatures -> IO (Maybe RVFI_IntData, RVFIFeatures, Int)
@@ -291,15 +286,14 @@ rvfiDecodeIntData = do
   rs1_addr <- getWord8
   rs2_addr <- getWord8
   skip 5 -- 5 bytes of padding
-  return
-    $! RVFI_IntData
-      { rvfi_rd_wdata = rd_wdata,
-        rvfi_rs1_rdata = rs1_rdata,
-        rvfi_rs2_rdata = rs2_rdata,
-        rvfi_rd_addr = rd_addr,
-        rvfi_rs1_addr = rs1_addr,
-        rvfi_rs2_addr = rs2_addr
-      }
+  return $! RVFI_IntData {
+      rvfi_rd_wdata = rd_wdata
+    , rvfi_rs1_rdata = rs1_rdata
+    , rvfi_rs2_rdata = rs2_rdata
+    , rvfi_rd_addr = rd_addr
+    , rvfi_rs1_addr = rs1_addr
+    , rvfi_rs2_addr = rs2_addr
+    }
 
 rvfiMaybeReadMemData :: (Int64 -> IO BS.ByteString, String, Int) -> RVFIFeatures -> IO (Maybe RVFI_MemAccessData, RVFIFeatures, Int)
 rvfiMaybeReadMemData connection availableFeatures = do
@@ -323,14 +317,13 @@ rvfiDecodeMemData = do
   mem_rmask <- getWord32le
   mem_wmask <- getWord32le
   mem_addr <- getWord64le
-  return
-    $! RVFI_MemAccessData
-      { rvfi_mem_addr = mem_addr,
-        rvfi_mem_rmask = mem_rmask,
-        rvfi_mem_wmask = mem_wmask,
-        rvfi_mem_rdata = Basement.Types.Word256.Word256 rdata4 rdata3 rdata2 rdata1,
-        rvfi_mem_wdata = Basement.Types.Word256.Word256 wdata4 wdata3 wdata2 wdata1
-      }
+  return $! RVFI_MemAccessData {
+      rvfi_mem_addr = mem_addr
+    , rvfi_mem_rmask = mem_rmask
+    , rvfi_mem_wmask = mem_wmask
+    , rvfi_mem_rdata = Basement.Types.Word256.Word256 rdata4 rdata3 rdata2 rdata1
+    , rvfi_mem_wdata = Basement.Types.Word256.Word256 wdata4 wdata3 wdata2 wdata1
+    }
 
 rvfiReadV1Response :: (Int64 -> IO BS.ByteString, String, Int) -> IO RVFI_Packet
 rvfiReadV1Response (reader, name, verbosity) = do
@@ -359,37 +352,31 @@ rvfiDecodeV1Response = do
   pc_wdata <- getWord64be
   pc_rdata <- getWord64be
   order <- getWord64be
-  return $
-    RVFI_Packet
-      { rvfi_valid = 1,
-        rvfi_order = order,
-        rvfi_insn = insn,
-        rvfi_trap = trap,
-        rvfi_halt = halt,
-        rvfi_intr = intr,
-        rvfi_mode = Nothing,
-        rvfi_ixl = Nothing,
-        rvfi_pc_rdata = pc_rdata,
-        rvfi_pc_wdata = pc_wdata,
-        rvfi_int_data =
-          Just
-            RVFI_IntData
-              { rvfi_rs1_addr = rs1_addr,
-                rvfi_rs2_addr = rs2_addr,
-                rvfi_rs1_rdata = rs1_rdata,
-                rvfi_rs2_rdata = rs2_rdata,
-                rvfi_rd_addr = rd_addr,
-                rvfi_rd_wdata = rd_wdata
-              },
-        rvfi_mem_data =
-          Just
-            RVFI_MemAccessData
-              { rvfi_mem_addr = mem_addr,
-                rvfi_mem_rmask = fromIntegral mem_rmask, -- FIXME: I think this zero-extends?
-                rvfi_mem_wmask = fromIntegral mem_wmask, -- FIXME: I think this zero-extends?
-                rvfi_mem_rdata = Basement.Types.Word256.Word256 0 0 0 mem_rdata,
-                rvfi_mem_wdata = Basement.Types.Word256.Word256 0 0 0 mem_wdata
-              }
+  return $ RVFI_Packet { rvfi_valid = 1,
+      rvfi_order = order
+    , rvfi_insn = insn
+    , rvfi_trap = trap
+    , rvfi_halt = halt
+    , rvfi_intr = intr
+    , rvfi_mode = Nothing
+    , rvfi_ixl = Nothing
+    , rvfi_pc_rdata = pc_rdata
+    , rvfi_pc_wdata = pc_wdata
+    , rvfi_int_data = Just RVFI_IntData {
+        rvfi_rs1_addr = rs1_addr
+      , rvfi_rs2_addr = rs2_addr
+      , rvfi_rs1_rdata = rs1_rdata
+      , rvfi_rs2_rdata = rs2_rdata
+      , rvfi_rd_addr = rd_addr
+      , rvfi_rd_wdata = rd_wdata
+      }
+    , rvfi_mem_data = Just RVFI_MemAccessData {
+         rvfi_mem_addr = mem_addr
+        , rvfi_mem_rmask = fromIntegral mem_rmask -- FIXME: I think this zero-extends?
+        , rvfi_mem_wmask = fromIntegral mem_wmask -- FIXME: I think this zero-extends?
+        , rvfi_mem_rdata = Basement.Types.Word256.Word256 0 0 0 mem_rdata
+        , rvfi_mem_wdata = Basement.Types.Word256.Word256 0 0 0 mem_wdata
+        }
       }
 
 -- | An otherwise empty halt token for padding
@@ -481,5 +468,5 @@ rvfiCheck is64 x y
 --   each input 'RVFI_Packet' if inputs are not succeeding the 'rvfiCheck'
 rvfiCheckAndShow :: Bool -> RVFI_Packet -> RVFI_Packet -> (Bool, String)
 rvfiCheckAndShow is64 x y
-  | rvfiCheck is64 x y = (True, "     " ++ show x)
-  | otherwise = (False, " A < " ++ show x ++ "\n B > " ++ show y)
+  | rvfiCheck is64 x y = (True,  "     " ++ show x)
+  | otherwise          = (False, " A < " ++ show x ++ "\n B > " ++ show y)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -93,8 +93,11 @@ type RV_XL = Word8
 
 -- | The 'RVFI_Packet' type captures (a subset of) the RISC-V Formal Interface
 data RVFI_Packet = RVFI_Packet {
+-- The trace version used to decode this packet. This is used to ignore parts
+-- of fields that are only present in version 2 (or newer).
+  rvfi_trace_version :: Int
 -- Metadata
-  rvfi_valid :: Word8
+, rvfi_valid :: Word8
 , rvfi_order :: Word64
 , rvfi_insn  :: Word64
 , rvfi_trap  :: Word8
@@ -253,7 +256,8 @@ rvfiDecodeV2Header = do
   pc_wdata <- getWord64le
   availableFeatures <- getWord64le
   return $ (RVFI_Packet {
-      rvfi_valid = valid
+      rvfi_trace_version = 2
+    , rvfi_valid = valid
     , rvfi_order = order
     , rvfi_insn = insn
     , rvfi_trap = trap
@@ -352,8 +356,10 @@ rvfiDecodeV1Response = do
   pc_wdata <- getWord64be
   pc_rdata <- getWord64be
   order <- getWord64be
-  return $ RVFI_Packet { rvfi_valid = 1,
-      rvfi_order = order
+  return $ RVFI_Packet {
+      rvfi_trace_version = 1
+    , rvfi_valid = 1
+    , rvfi_order = order
     , rvfi_insn = insn
     , rvfi_trap = trap
     , rvfi_halt = halt
@@ -381,20 +387,20 @@ rvfiDecodeV1Response = do
 
 -- | An otherwise empty halt token for padding
 rvfiEmptyHaltPacket :: RVFI_Packet
-rvfiEmptyHaltPacket =
-  RVFI_Packet
-    { rvfi_halt = 1,
-      rvfi_valid = 0,
-      rvfi_order = 0,
-      rvfi_insn = 0,
-      rvfi_trap = 0,
-      rvfi_intr = 0,
-      rvfi_mode = Nothing,
-      rvfi_ixl = Nothing,
-      rvfi_pc_rdata = 0,
-      rvfi_pc_wdata = 0,
-      rvfi_int_data = Nothing,
-      rvfi_mem_data = Nothing
+rvfiEmptyHaltPacket = RVFI_Packet {
+      rvfi_trace_version = 0
+    , rvfi_halt = 1
+    , rvfi_valid = 0
+    , rvfi_order = 0
+    , rvfi_insn = 0
+    , rvfi_trap = 0
+    , rvfi_intr = 0
+    , rvfi_mode = Nothing
+    , rvfi_ixl = Nothing
+    , rvfi_pc_rdata = 0
+    , rvfi_pc_wdata = 0
+    , rvfi_int_data = Nothing
+    , rvfi_mem_data = Nothing
     }
 
 prvString :: Maybe RV_PrivMode -> String

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -55,7 +55,6 @@ module QuickCheckVEngine.RVFI_DII.RVFI (
 , rvfiCheck
 , rvfiCheckAndShow
 , rvfiCheckMagicBytes
-, rvfiCheckAndShow
 , rvfiReadDataPacketWithMagic
 , rvfiReadV1Response
 , rvfiReadV2Response

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -77,6 +77,7 @@ import qualified Data.ByteString.Lazy.Char8 as C8
 import Data.Int
 import Data.Maybe
 import RISCV
+import RISCV.Helpers (privString, xlenString)
 import Text.Printf
 
 -- | Type synonym for a RISCV register index
@@ -84,10 +85,6 @@ type RV_RegIdx = Word8
 
 -- | Type synonym for a RISCV XLEN-bit word
 type RV_WordXLEN = Word64
-
-data RV_PrivMode = PRV_U | PRV_S | PRV_Reserved | PRV_M deriving (Enum, Show, Eq)
-
-type RV_XL = Word8
 
 -- * Definition of the RISC-V Formal Interface
 
@@ -103,8 +100,8 @@ data RVFI_Packet = RVFI_Packet {
 , rvfi_trap  :: Word8
 , rvfi_halt  :: Word8
 , rvfi_intr  :: Word8
-, rvfi_mode  :: Maybe RV_PrivMode
-, rvfi_ixl   :: Maybe RV_XL
+, rvfi_mode  :: Maybe RISCV.PrivMode
+, rvfi_ixl   :: Maybe RISCV.XLen
 -- Program Counter
 , rvfi_pc_rdata :: RV_WordXLEN
 , rvfi_pc_wdata :: RV_WordXLEN
@@ -384,17 +381,6 @@ rvfiEmptyHaltPacket = RVFI_Packet {
     , rvfi_mem_data = Nothing
     }
 
-prvString :: Maybe RV_PrivMode -> String
-prvString Nothing = "PRV_?"
-prvString (Just x) = show x
-
-ixlString :: Maybe RV_XL -> String
-ixlString Nothing = "?"
-ixlString (Just 1) = "32"
-ixlString (Just 2) = "64"
-ixlString (Just 3) = "128"
-ixlString (Just _) = "Invalid"
-
 instance Show RVFI_Packet where
   show tok
     | rvfiIsHalt tok = "halt token"
@@ -409,8 +395,8 @@ instance Show RVFI_Packet where
         (toNatural (maybe 0 rvfi_mem_wdata $ rvfi_mem_data tok)) -- MWD
         (maybe 0 rvfi_mem_wmask $ rvfi_mem_data tok) -- MWM
         (rvfi_insn tok)
-        (prvString (rvfi_mode tok))
-        (ixlString (rvfi_ixl tok))
+        (privString (rvfi_mode tok))
+        (xlenString (rvfi_ixl tok))
         (pretty (toInteger (rvfi_insn tok))) -- Inst
 
 -- | Return 'True' for halt 'RVFI_Packet's

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -332,7 +332,7 @@ rvfiDecodeMemData = do
 rvfiReadV1Response :: (Int64 -> IO BS.ByteString, String, Int) -> IO RVFI_Packet
 rvfiReadV1Response (reader, name, verbosity) = do
   msg <- reader 88
-  connectionDebugMessage 2 (name, verbosity) ("read packet: " ++ hexStr msg)
+  connectionDebugMessage 3 (name, verbosity) ("read packet: " ++ hexStr msg)
   -- Note: BS.reverse since the decode was written in BE order
   return $ runGet (isolate 88 rvfiDecodeV1Response) (BS.reverse msg)
 

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -402,12 +402,18 @@ prvString :: Maybe RV_PrivMode -> String
 prvString Nothing = "PRV_?"
 prvString (Just x) = show x
 
+ixlString :: Maybe RV_XL -> String
+ixlString Nothing = "?"
+ixlString (Just 1) = "32"
+ixlString (Just 2) = "64"
+ixlString (Just _) = "Invalid"
+
 instance Show RVFI_Packet where
   show tok
     | rvfiIsHalt tok = "halt token"
     | otherwise =
       printf
-        "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x %s (%s)"
+        "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x %s XL:%s (%s)"
         (show $ rvfi_trap tok /= 0) -- Trap
         (rvfi_pc_wdata tok) -- PCWD
         (rvfi_rd_addr intData) -- RD
@@ -417,6 +423,7 @@ instance Show RVFI_Packet where
         (rvfi_mem_wmask memData) -- MWM
         (rvfi_insn tok)
         (prvString (rvfi_mode tok))
+        (ixlString (rvfi_ixl tok))
         (pretty (toInteger (rvfi_insn tok))) -- Inst
     where
       intData = fromMaybe rvfiEmptyIntData (rvfi_int_data tok)
@@ -449,6 +456,7 @@ rvfiCheck is64 x y
       && (rvfi_trap x == rvfi_trap y)
       && (rvfi_halt x == rvfi_halt y)
       && (optionalFieldsSame (rvfi_mode x) (rvfi_mode y))
+      && (optionalFieldsSame (rvfi_ixl x) (rvfi_ixl y))
       && (rvfi_rd_addr xInt == rvfi_rd_addr yInt)
       && ((rvfi_rd_addr xInt == 0) || (maskUpper is64 (rvfi_rd_wdata xInt) == maskUpper is64 (rvfi_rd_wdata yInt)))
       && (rvfi_mem_wmask xMem == rvfi_mem_wmask yMem)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -70,6 +70,7 @@ import Data.Word
 import Data.Binary
 import Data.Binary.Get
 import Data.Bits
+import Data.Semigroup -- Should no longer be required with modern ghc
 import qualified Data.Bits.Bitwise as BW
 import qualified Data.ByteString.Lazy as BS
 import Data.ByteString.Lazy.Builder (lazyByteStringHex, toLazyByteString)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -4,6 +4,7 @@
 -- Copyright (c) 2018 Matthew Naylor
 -- Copyright (c) 2018 Jonathan Woodruff
 -- Copyright (c) 2018-2020 Alexandre Joannou
+-- Copyright (c) 2020 Alex Richardson
 -- All rights reserved.
 --
 -- This software was developed by SRI International and the University of
@@ -37,34 +38,32 @@
 -- SUCH DAMAGE.
 --
 
-{-|
-    Module      : QuickCheckVEngine.RVFI_DII.RVFI
-    Description : RISC-V Formal Interface
-
-    The 'QuickCheckVEngine.RVFI_DII.RVFI' module defines the RISC-V RVFI
-    interface as introduced
-    <https://github.com/SymbioticEDA/riscv-formal/blob/master/docs/rvfi.md here>
--}
-
-module QuickCheckVEngine.RVFI_DII.RVFI (
-  RVFI_Packet (..)
-, rvfiEmptyHaltPacket
-, rvfiGetFromString
-, rvfiIsHalt
-, rvfiHaltVersion
-, rvfiIsTrap
-, rvfiCheck
-, rvfiCheckAndShow
-) where
+-- |
+--    Module      : QuickCheckVEngine.RVFI_DII.RVFI
+--    Description : RISC-V Formal Interface
+--
+--    The 'QuickCheckVEngine.RVFI_DII.RVFI' module defines the RISC-V RVFI
+--    interface as introduced
+--    <https://github.com/SymbioticEDA/riscv-formal/blob/master/docs/rvfi.md here>
+module QuickCheckVEngine.RVFI_DII.RVFI
+  ( RVFI_Packet,
+    rvfiEmptyHaltPacket,
+    rvfiGetFromString,
+    rvfiIsHalt,
+    rvfiHaltVersion,
+    rvfiIsTrap,
+    rvfiCheck,
+    rvfiCheckAndShow,
+  )
+where
 
 import Data.Word
+import Data.Binary
+import Data.Binary.Get
 import Data.Bits
 import qualified Data.Bits.Bitwise as BW
-import Data.Binary
-import Data.Binary.Put
-import Data.Binary.Get
 import qualified Data.ByteString.Lazy as BS
-import Data.Semigroup -- Should no longer be required with modern ghc
+import Data.Maybe
 import RISCV
 import Text.Printf
 
@@ -74,46 +73,38 @@ type RV_RegIdx = Word8
 -- | Type synonym for a RISCV XLEN-bit word
 type RV_WordXLEN = Word64
 
--- | Type synonym for a RISCV XLEN-bit word
-type RV_WordXLEN_ByteMask = Word8
+data RV_PrivMode = PRV_U | PRV_S | PRV_Reserved | PRV_M deriving (Enum, Show)
+
+type RV_XL = Word8
 
 -- * Definition of the RISC-V Formal Interface
 
 -- | The 'RVFI_Packet' type captures (a subset of) the RISC-V Formal Interface
-data RVFI_Packet = RVFI_Packet {
--- Metadata
-  rvfi_valid :: Word8
-, rvfi_order :: Word64
-, rvfi_insn  :: Word64
-, rvfi_trap  :: Word8
-, rvfi_halt  :: Word8
-, rvfi_intr  :: Word8
---, rvfi_mode  :: RV_PrivMode -- TODO
---, rvfi_ixl   :: RV_XL       -- TODO
--- Integer Register Read/Write
-, rvfi_rs1_addr  :: RV_RegIdx
-, rvfi_rs2_addr  :: RV_RegIdx
-, rvfi_rs1_rdata :: RV_WordXLEN
-, rvfi_rs2_rdata :: RV_WordXLEN
-, rvfi_rd_addr   :: RV_RegIdx
-, rvfi_rd_wdata  :: RV_WordXLEN
--- Program Counter
-, rvfi_pc_rdata :: RV_WordXLEN
-, rvfi_pc_wdata :: RV_WordXLEN
--- Memory Access
-, rvfi_mem_addr  :: RV_WordXLEN
-, rvfi_mem_rmask :: RV_WordXLEN_ByteMask
-, rvfi_mem_wmask :: RV_WordXLEN_ByteMask
-, rvfi_mem_rdata :: RV_WordXLEN
-, rvfi_mem_wdata :: RV_WordXLEN
--- Further TODOs in the RVFI specification:
--- Control and Status Registers (CSRs)
--- Modelling of Floating-Point State
--- Handling of Speculative Execution
--- Modelling of Virtual Memory
--- Modelling of Atomic Memory Operations
--- Skipping instructions
-}
+data RVFI_Packet = RVFI_Packet
+  { -- Metadata
+    rvfi_valid :: Word8,
+    rvfi_order :: Word64,
+    rvfi_insn :: Word64,
+    rvfi_trap :: Word8,
+    rvfi_halt :: Word8,
+    rvfi_intr :: Word8,
+    rvfi_mode :: Maybe RV_PrivMode,
+    rvfi_ixl :: Maybe RV_XL,
+    -- Program Counter
+    rvfi_pc_rdata :: RV_WordXLEN,
+    rvfi_pc_wdata :: RV_WordXLEN,
+    -- Integer Register Read/Write
+    rvfi_int_data :: Maybe RVFI_IntData,
+    -- Memory Access
+    rvfi_mem_data :: Maybe RVFI_MemAccessData
+    -- Further TODOs in the RVFI specification:
+    -- Control and Status Registers (CSRs)
+    -- Modelling of Floating-Point State
+    -- Handling of Speculative Execution
+    -- Modelling of Virtual Memory
+    -- Modelling of Atomic Memory Operations
+    -- Skipping instructions
+  }
 
 rvfiGetFromString "valid"     = Just $ toInteger . rvfi_valid
 rvfiGetFromString "order"     = Just $ toInteger . rvfi_order
@@ -136,66 +127,97 @@ rvfiGetFromString "mem_rdata" = Just $ toInteger . rvfi_mem_rdata
 rvfiGetFromString "mem_wdata" = Just $ toInteger . rvfi_mem_wdata
 rvfiGetFromString _           = Nothing
 
+data RVFI_IntData = RVFI_IntData
+  { rvfi_rs1_addr :: RV_RegIdx,
+    rvfi_rs2_addr :: RV_RegIdx,
+    rvfi_rs1_rdata :: RV_WordXLEN,
+    rvfi_rs2_rdata :: RV_WordXLEN,
+    rvfi_rd_addr :: RV_RegIdx,
+    rvfi_rd_wdata :: RV_WordXLEN
+  }
+
+rvfiEmptyIntData :: RVFI_IntData
+rvfiEmptyIntData =
+  RVFI_IntData
+    { rvfi_rs1_addr = 0,
+      rvfi_rs2_addr = 0,
+      rvfi_rs1_rdata = 0,
+      rvfi_rs2_rdata = 0,
+      rvfi_rd_addr = 0,
+      rvfi_rd_wdata = 0
+    }
+
+data RVFI_MemAccessData = RVFI_MemAccessData
+  { rvfi_mem_addr :: RV_WordXLEN,
+    rvfi_mem_rmask :: Word32,
+    rvfi_mem_wmask :: Word32,
+    rvfi_mem_rdata :: RV_WordXLEN,
+    rvfi_mem_wdata :: RV_WordXLEN
+  }
+
+rvfiEmptyMemData :: RVFI_MemAccessData
+rvfiEmptyMemData =
+  RVFI_MemAccessData
+    { rvfi_mem_addr = 0,
+      rvfi_mem_rmask = 0,
+      rvfi_mem_wmask = 0,
+      rvfi_mem_rdata = 0,
+      rvfi_mem_wdata = 0
+    }
+
 instance Binary RVFI_Packet where
-  put pkt =    putWord8    (rvfi_intr pkt)
-            <> putWord8    (rvfi_halt pkt)
-            <> putWord8    (rvfi_trap pkt)
-            <> putWord8    (rvfi_rd_addr pkt)
-            <> putWord8    (rvfi_rs2_addr pkt)
-            <> putWord8    (rvfi_rs1_addr pkt)
-            <> putWord8    (rvfi_mem_wmask pkt)
-            <> putWord8    (rvfi_mem_rmask pkt)
-            <> putWord64be (rvfi_mem_wdata pkt)
-            <> putWord64be (rvfi_mem_rdata pkt)
-            <> putWord64be (rvfi_mem_addr pkt)
-            <> putWord64be (rvfi_rd_wdata pkt)
-            <> putWord64be (rvfi_rs2_rdata pkt)
-            <> putWord64be (rvfi_rs1_rdata pkt)
-            <> putWord64be (rvfi_insn pkt)
-            <> putWord64be (rvfi_pc_wdata pkt)
-            <> putWord64be (rvfi_pc_rdata pkt)
-            <> putWord64be (rvfi_order pkt)
-  get = do intr      <- getWord8
-           halt      <- getWord8
-           trap      <- getWord8
-           rd_addr   <- getWord8
-           rs2_addr  <- getWord8
-           rs1_addr  <- getWord8
-           mem_wmask <- getWord8
-           mem_rmask <- getWord8
-           mem_wdata <- getWord64be
-           mem_rdata <- getWord64be
-           mem_addr  <- getWord64be
-           rd_wdata  <- getWord64be
-           rs2_rdata <- getWord64be
-           rs1_rdata <- getWord64be
-           insn      <- getWord64be
-           pc_wdata  <- getWord64be
-           pc_rdata  <- getWord64be
-           order     <- getWord64be
-           return $ RVFI_Packet {
-               rvfi_valid = 1
-             , rvfi_order = order
-             , rvfi_insn  = insn
-             , rvfi_trap  = trap
-             , rvfi_halt  = halt
-             , rvfi_intr  = intr
-             --, rvfi_mode = _
-             --, rvfi_ixl  = _
-             , rvfi_rs1_addr  = rs1_addr
-             , rvfi_rs2_addr  = rs2_addr
-             , rvfi_rs1_rdata = rs1_rdata
-             , rvfi_rs2_rdata = rs2_rdata
-             , rvfi_rd_addr   = rd_addr
-             , rvfi_rd_wdata  = rd_wdata
-             , rvfi_pc_rdata  = pc_rdata
-             , rvfi_pc_wdata  = pc_wdata
-             , rvfi_mem_addr  = mem_addr
-             , rvfi_mem_rmask = mem_rmask
-             , rvfi_mem_wmask = mem_wmask
-             , rvfi_mem_rdata = mem_rdata
-             , rvfi_mem_wdata = mem_wdata
-             }
+  put _ = error "Should not be called, we only read packets"
+  get = do
+    intr <- getWord8
+    halt <- getWord8
+    trap <- getWord8
+    rd_addr <- getWord8
+    rs2_addr <- getWord8
+    rs1_addr <- getWord8
+    mem_wmask <- getWord8
+    mem_rmask <- getWord8
+    mem_wdata <- getWord64be
+    mem_rdata <- getWord64be
+    mem_addr <- getWord64be
+    rd_wdata <- getWord64be
+    rs2_rdata <- getWord64be
+    rs1_rdata <- getWord64be
+    insn <- getWord64be
+    pc_wdata <- getWord64be
+    pc_rdata <- getWord64be
+    order <- getWord64be
+    return $
+      RVFI_Packet
+        { rvfi_valid = 1,
+          rvfi_order = order,
+          rvfi_insn = insn,
+          rvfi_trap = trap,
+          rvfi_halt = halt,
+          rvfi_intr = intr,
+          rvfi_mode = Nothing,
+          rvfi_ixl = Nothing,
+          rvfi_pc_rdata = pc_rdata,
+          rvfi_pc_wdata = pc_wdata,
+          rvfi_int_data =
+            Just
+              RVFI_IntData
+                { rvfi_rs1_addr = rs1_addr,
+                  rvfi_rs2_addr = rs2_addr,
+                  rvfi_rs1_rdata = rs1_rdata,
+                  rvfi_rs2_rdata = rs2_rdata,
+                  rvfi_rd_addr = rd_addr,
+                  rvfi_rd_wdata = rd_wdata
+                },
+          rvfi_mem_data =
+            Just
+              RVFI_MemAccessData
+                { rvfi_mem_addr = mem_addr,
+                  rvfi_mem_rmask = fromIntegral mem_rmask, -- FIXME: sign-extend/zero-extend?
+                  rvfi_mem_wmask = fromIntegral mem_wmask, -- FIXME: sign-extend/zero-extend?
+                  rvfi_mem_rdata = mem_rdata,
+                  rvfi_mem_wdata = mem_wdata
+                }
+        }
 
 -- | An otherwise empty halt token for padding
 rvfiEmptyHaltPacket :: RVFI_Packet
@@ -204,15 +226,22 @@ rvfiEmptyHaltPacket = (runGet get (BS.repeat 0)) { rvfi_halt = 1 }
 instance Show RVFI_Packet where
   show tok
     | rvfiIsHalt tok = printf "halt token v%d" (rvfiHaltVersion tok)
-    | otherwise = printf "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x (%s)"
-                  (show $ rvfi_trap tok /= 0) -- Trap
-                  (rvfi_pc_wdata tok)    -- PCWD
-                  (rvfi_rd_addr tok)     -- RD
-                  (rvfi_rd_wdata tok)    -- RWD
-                  (rvfi_mem_addr tok)    -- MA
-                  (rvfi_mem_wdata tok)   -- MWD
-                  (rvfi_mem_wmask tok)   -- MWM
-                  (rvfi_insn tok) (pretty (toInteger (rvfi_insn tok))) -- Inst
+    | otherwise =
+      printf
+        "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x P:%s (%s)"
+        (show $ rvfi_trap tok /= 0) -- Trap
+        (rvfi_pc_wdata tok) -- PCWD
+        (rvfi_rd_addr intData) -- RD
+        (rvfi_rd_wdata intData) -- RWD
+        (rvfi_mem_addr memData) -- MA
+        (rvfi_mem_wdata memData) -- MWD
+        (rvfi_mem_wmask memData) -- MWM
+        (rvfi_insn tok)
+        (show (rvfi_mode tok))
+        (pretty (toInteger (rvfi_insn tok))) -- Inst
+    where
+      intData = fromMaybe rvfiEmptyIntData (rvfi_int_data tok)
+      memData = fromMaybe rvfiEmptyMemData (rvfi_mem_data tok)
 
 -- | Return 'True' for halt 'RVFI_Packet's
 rvfiIsHalt :: RVFI_Packet -> Bool
@@ -227,26 +256,34 @@ rvfiIsTrap :: RVFI_Packet -> Bool
 rvfiIsTrap x = rvfi_trap x /= 0
 
 -- | Compare 'RVFI_Packet's
+-- TODO: Improve handling of Maybe values
 rvfiCheck :: Bool -> RVFI_Packet -> RVFI_Packet -> Bool
 rvfiCheck is64 x y
-  | rvfiIsHalt x = (rvfi_halt x) == (rvfi_halt y)
-  | rvfiIsTrap x = ((rvfi_trap x) == (rvfi_trap y)) && (maskUpper is64 (rvfi_pc_wdata x)) == (maskUpper is64 (rvfi_pc_wdata y))
-  | otherwise = (maskUpper False $ rvfi_insn x) == (maskUpper False $ rvfi_insn y) &&
-                (rvfi_trap x) == (rvfi_trap y) && (rvfi_halt x) == (rvfi_halt y) &&
-                (rvfi_rd_addr x == rvfi_rd_addr y) &&
-                ((rvfi_rd_addr x == 0) || (maskUpper is64 (rvfi_rd_wdata x) == maskUpper is64 (rvfi_rd_wdata y))) &&
-                (rvfi_mem_wmask x) == (rvfi_mem_wmask y) &&
-                ((rvfi_mem_wmask x == 0) || ((maskUpper is64 (rvfi_mem_addr x)) == (maskUpper is64 (rvfi_mem_addr y)))) &&
-                (maskUpper is64 (rvfi_pc_wdata x)) == (maskUpper is64 (rvfi_pc_wdata y)) &&
-                (maskWith (rvfi_mem_wdata x) (rvfi_mem_wmask x)) == (maskWith (rvfi_mem_wdata y) (rvfi_mem_wmask y))
-  where maskUpper is64 x = if is64 then x else (x Data.Bits..&. 0x00000000FFFFFFFF)
-        byteMask2bitMask mask = BW.fromListLE $ concatMap ((take 8).repeat) (BW.toListLE mask)
-        maskWith a b = a Data.Bits..&. byteMask2bitMask b
+  | rvfiIsHalt x = rvfi_halt x == rvfi_halt y
+  | rvfiIsTrap x = (rvfi_trap x == rvfi_trap y) && (maskUpper is64 (rvfi_pc_wdata x) == maskUpper is64 (rvfi_pc_wdata y))
+  | otherwise =
+    (maskUpper False (rvfi_insn x) == maskUpper False (rvfi_insn y))
+      && (rvfi_trap x == rvfi_trap y)
+      && (rvfi_halt x == rvfi_halt y)
+      && (rvfi_rd_addr xInt == rvfi_rd_addr yInt)
+      && ((rvfi_rd_addr xInt == 0) || (maskUpper is64 (rvfi_rd_wdata xInt) == maskUpper is64 (rvfi_rd_wdata yInt)))
+      && (rvfi_mem_wmask xMem == rvfi_mem_wmask yMem)
+      && ((rvfi_mem_wmask xMem == 0) || (maskUpper is64 (rvfi_mem_addr xMem) == maskUpper is64 (rvfi_mem_addr yMem)))
+      && (maskUpper is64 (rvfi_pc_wdata x) == maskUpper is64 (rvfi_pc_wdata y))
+      && (maskWith (rvfi_mem_wdata xMem) (rvfi_mem_wmask xMem) == maskWith (rvfi_mem_wdata yMem) (rvfi_mem_wmask yMem))
+  where
+    maskUpper _is64 _x = if _is64 then _x else _x Data.Bits..&. 0x00000000FFFFFFFF
+    byteMask2bitMask mask = BW.fromListLE $ concatMap (replicate 8) (BW.toListLE mask)
+    maskWith a b = a Data.Bits..&. byteMask2bitMask b
+    xInt = fromMaybe rvfiEmptyIntData (rvfi_int_data x)
+    yInt = fromMaybe rvfiEmptyIntData (rvfi_int_data y)
+    xMem = fromMaybe rvfiEmptyMemData (rvfi_mem_data x)
+    yMem = fromMaybe rvfiEmptyMemData (rvfi_mem_data y)
 
 -- | Compare 2 'RVFI_Packet's and produce a 'String' output displaying the
 --   the content of the packet once only for equal inputs or the content of
 --   each input 'RVFI_Packet' if inputs are not succeeding the 'rvfiCheck'
 rvfiCheckAndShow :: Bool -> RVFI_Packet -> RVFI_Packet -> (Bool, String)
 rvfiCheckAndShow is64 x y
-  | rvfiCheck is64 x y = (True,  "     " ++ show x)
-  | otherwise          = (False, " A < " ++ show x ++ "\n B > " ++ show y)
+  | rvfiCheck is64 x y = (True, "     " ++ show x)
+  | otherwise = (False, " A < " ++ show x ++ "\n B > " ++ show y)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -117,6 +117,7 @@ data RVFI_Packet = RVFI_Packet
     -- Skipping instructions
   }
 
+rvfiGetFromString :: [Char] -> Maybe (RVFI_Packet -> Integer)
 rvfiGetFromString "valid"     = Just $ toInteger . rvfi_valid
 rvfiGetFromString "order"     = Just $ toInteger . rvfi_order
 rvfiGetFromString "insn"      = Just $ toInteger . rvfi_insn
@@ -316,7 +317,6 @@ rvfiDecodeMemData = do
   wdata2 <- getWord64le
   wdata3 <- getWord64le
   wdata4 <- getWord64le
-  let rd_rdata = Basement.Types.Word256.Word256 rdata1 rdata2 rdata3 rdata4
   mem_rmask <- getWord32le
   mem_wmask <- getWord32le
   mem_addr <- getWord64le

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -446,9 +446,9 @@ rvfiHaltVersion x = 1 + shiftR (rvfi_halt x) 1
 rvfiIsTrap :: RVFI_Packet -> Bool
 rvfiIsTrap x = rvfi_trap x /= 0
 
-privLevelSame :: (Maybe RV_PrivMode) -> (Maybe RV_PrivMode) -> Bool
-privLevelSame x y = fromMaybe False (mzipWith (==) x y)
-
+-- | Compare two Maybe fields, but assume success if one of them does not exist.
+optionalFieldsSame :: Eq a => (Maybe a) -> (Maybe a) -> Bool
+optionalFieldsSame x y = fromMaybe True (mzipWith (==) x y)
 
 -- | Compare 'RVFI_Packet's
 -- TODO: Improve handling of Maybe values
@@ -460,7 +460,7 @@ rvfiCheck is64 x y
     (maskUpper False (rvfi_insn x) == maskUpper False (rvfi_insn y))
       && (rvfi_trap x == rvfi_trap y)
       && (rvfi_halt x == rvfi_halt y)
-      && (privLevelSame (rvfi_mode x) (rvfi_mode y))
+      && (optionalFieldsSame (rvfi_mode x) (rvfi_mode y))
       && (rvfi_rd_addr xInt == rvfi_rd_addr yInt)
       && ((rvfi_rd_addr xInt == 0) || (maskUpper is64 (rvfi_rd_wdata xInt) == maskUpper is64 (rvfi_rd_wdata yInt)))
       && (rvfi_mem_wmask xMem == rvfi_mem_wmask yMem)

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -416,7 +416,7 @@ prvString (Just x) = show x
 
 instance Show RVFI_Packet where
   show tok
-    | rvfiIsHalt tok = printf "halt token v%d" (rvfiHaltVersion tok)
+    | rvfiIsHalt tok = "halt token"
     | otherwise =
       printf
         "Trap: %5s, PCWD: 0x%016x, RD: %02d, RWD: 0x%016x, MA: 0x%016x, MWD: 0x%016x, MWM: 0b%08b, I: 0x%016x %s (%s)"

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -65,6 +65,7 @@ where
 import Basement.Numerical.Number (toNatural)
 import qualified Basement.Types.Word256
 import Control.Monad
+import Control.Monad.Zip (mzipWith)
 import Data.Word
 import Data.Binary
 import Data.Binary.Get
@@ -445,13 +446,8 @@ rvfiHaltVersion x = 1 + shiftR (rvfi_halt x) 1
 rvfiIsTrap :: RVFI_Packet -> Bool
 rvfiIsTrap x = rvfi_trap x /= 0
 
--- | Since version 1 trace format implementations don't report the current privilege
--- | level we can't fail the comparison if one implementation reports a privilege level
--- | and the other one does
 privLevelSame :: (Maybe RV_PrivMode) -> (Maybe RV_PrivMode) -> Bool
-privLevelSame _ Nothing = True
-privLevelSame Nothing _ = True
-privLevelSame x y = (x == y)
+privLevelSame x y = fromMaybe False (mzipWith (==) x y)
 
 
 -- | Compare 'RVFI_Packet's

--- a/src/QuickCheckVEngine/Template.hs
+++ b/src/QuickCheckVEngine/Template.hs
@@ -137,7 +137,7 @@ assertSingle insn assert str = Assert (Single insn)
 
 -- | Wrap a single instruction in an assert that it writes back a given value
 assertSingleRWD :: Integer -> Integer -> String -> Template
-assertSingleRWD insn target str = assertSingle insn (\z -> toInteger (rvfi_rd_wdata z) == target) str
+assertSingleRWD insn target str = assertSingle insn (\z -> toInteger (rvfi_rd_wdata_or_zero z) == target) str
 
 -- | 'TestCase' type for generated 'Template'
 data TestCase = TC ([RVFI_Packet] -> [String]) [TestStrand]

--- a/src/RISCV.hs
+++ b/src/RISCV.hs
@@ -61,10 +61,13 @@ module RISCV (
 , module RISCV.RV_CSRs
 , module RISCV.HPMEvents
 , module RISCV.Shrinks
+, PrivMode
+, XLen
 ) where
 
 import RISCV.ArchDesc
 import RISCV.InstPretty
+import RISCV.Helpers (PrivMode, XLen)
 import RISCV.RV32_I
 import RISCV.RV32_M
 import RISCV.RV32_A

--- a/src/RISCV/Helpers.hs
+++ b/src/RISCV/Helpers.hs
@@ -74,13 +74,32 @@ module RISCV.Helpers (
 , reg
 , int
 , fpRoundingMode
+, PrivMode
+, privString
+, XLen
+, xlenString
 ) where
 
 import Numeric
 import Data.Maybe
+import Data.Word (Word8)
 import RISCV.RV_CSRs
 
+data PrivMode = PRV_U | PRV_S | PRV_Reserved | PRV_M deriving (Enum, Show, Eq)
+privString :: Maybe PrivMode -> String
+privString Nothing = "PRV_?"
+privString (Just x) = show x
+
+type XLen = Word8
+xlenString :: Maybe XLen -> String
+xlenString Nothing = "?"
+xlenString (Just 1) = "32"
+xlenString (Just 2) = "64"
+xlenString (Just 3) = "128"
+xlenString (Just _) = "Invalid"
+
 -- | Integer register pretty printer
+reg :: Integer -> String
 reg = intReg
 
 -- | Gives a RISCV register name 'String' when provided an 'Integer' index

--- a/src/RISCV/RV_CSRs.hs
+++ b/src/RISCV/RV_CSRs.hs
@@ -174,6 +174,10 @@ csrs_map = -- User Trap Setup
         ++ [ (0xB80 + x, "mhpmcounter" ++ show x ++ "h") | x <- hpmcounter_indices ]
         ++ -- Machine Counter Setup
            [ (0x320, "mcountinhibit") ]
+        ++ -- CHERI CSRs
+           [ (0x8C0, "uccsr")
+           , (0x9C0, "sccsr")
+           , (0xBC0, "mccsr") ]
         ++ map (\x -> (x, "mhpmevent" ++ show (x - (head hpmevent_csr_indices) + 3)))
                hpmevent_csr_indices
         -- TODO Debug/Trace Registers (shared with Debug Mode)


### PR DESCRIPTION
This is backwards compatible, old implementations can still report
version1  traces and we won't compare fields that aren't present yet (e.g. privilege level).