### PR TITLE
Stack: Use a newer LTS resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
-# resolver: lts-3.5
-# Note: lts-13.30 seems to be the only version that include quickcheck 2.12
-resolver: lts-13.30
+resolver: lts-18.28
 
 # User packages to be built.
 packages:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    hackage: bitwise-1.0.0.1@sha256:b5c988b1ceba6c8a7b1fa4b2aa8c69d8fbdc96145b8f22ad8e2c529d5688a66b,3110
+    hackage: bitwise-1.0.0.1@sha256:04c0e0c65a9228d9e004b5c4b08633b2f0e915afe8f3affc9bd16f75f92ccf61,3110
     pantry-tree:
       size: 760
-      sha256: eb8c35faaab3ea0205e89b5714c65b5bbe82bbf0f0c45ea859a8ea2fe457b04d
+      sha256: fe95409d2e77769965df68eade44e6eb5fcc63643a94e2645cd5db357670b20f
   original:
     hackage: bitwise-1.0.0.1
 snapshots:
 - completed:
-    size: 500539
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/30.yaml
-    sha256: 59ad6b944c9903847fecdc1d4815e8500c1f9999d80fd1b4d2d66e408faec44b
-  original: lts-13.30
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+  original: lts-18.28


### PR DESCRIPTION
Now that we no longer need QuickCheck 2.12, but can use newer versions,
there is no need to use the 13.30 LTS resolver.
This allows me to get better code completion in IntelliJ.