### PR TITLE
Only run HPM tests when Zihpm is supported

### DIFF
--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -206,12 +206,12 @@ allTests = [
            -- CSC: Capability Speculation Constraint
            -- BSC: Branching Speculation Constraint
            -- TSC: Translation Speculation Constraint
-           , ("csc_data",   "Data CSC Verification",                                  andPs [has_cheri, has_icsr],              const gen_csc_data_verify)
-           , ("bsc_cond_1", "BSC Condition 1 Verification",                           andPs [has_cheri, has_icsr, has_xlen_64], gen_bsc_cond_1_verify)
-           , ("bsc_jumps",  "BSC Jumps Verification",                                 andPs [has_cheri, has_icsr, has_xlen_64], const gen_bsc_jumps_verify)
-           , ("bsc_excps",  "BSC Exceptions Verification",                           andPs [has_cheri, has_icsr, has_xlen_64], gen_bsc_exceptions_verify)
-           , ("tsc",        "TSC Verification",                                       andPs [has_s, has_icsr, has_xlen_64],     const gen_tsc_verify)
-           , ("csc_inst",   "Instruction CSC Verification",                           andPs [has_cheri, has_icsr, has_xlen_64], const gen_csc_inst_verify)
+           , ("csc_data",   "Data CSC Verification",                                  andPs [has_cheri, has_icsr, has_ihpm],              const gen_csc_data_verify)
+           , ("bsc_cond_1", "BSC Condition 1 Verification",                           andPs [has_cheri, has_icsr, has_ihpm, has_xlen_64], gen_bsc_cond_1_verify)
+           , ("bsc_jumps",  "BSC Jumps Verification",                                 andPs [has_cheri, has_icsr, has_ihpm, has_xlen_64], const gen_bsc_jumps_verify)
+           , ("bsc_excps",  "BSC Exceptions Verification",                            andPs [has_cheri, has_icsr, has_ihpm, has_xlen_64], gen_bsc_exceptions_verify)
+           , ("tsc",        "TSC Verification",                                       andPs [has_s, has_icsr, has_ihpm, has_xlen_64],     const gen_tsc_verify)
+           , ("csc_inst",   "Instruction CSC Verification",                           andPs [has_cheri, has_icsr, has_ihpm, has_xlen_64], const gen_csc_inst_verify)
            , ("mem",        "Memory Verification",                                    const True,                               const $ T.repeatTillEnd gen_rv32_i_memory)
            , ("control",    "Control Flow Verification",                              const True,                               const $ T.repeatTillEnd gen_rv32_i_controlflow)
            , ("cache",      "Cache Verification",                                     const True,                               const $ T.repeatTillEnd gen_rv32_i_cache)
@@ -235,7 +235,7 @@ allTests = [
            , ("fencei",     "Zifencei Extension Verification",                        has_ifencei,                              const $ T.repeatTillEnd gen_rv32_i_zifencei_memory)
            , ("fencei64",   "RV64 Zifencei Extension Verification",                   andPs [has_ifencei, has_xlen_64],         const $ T.repeatTillEnd gen_rv64_i_zifencei_memory)
            , ("pte",        "PTE Verification",                                       has_s,                                    const $ T.repeatN 2 $ T.uniform [gen_pte_perms, gen_pte_trans])
-           , ("hpm",        "HPM Verification",                                       has_icsr,                                 T.repeatTillEnd . genHPM)
+           , ("hpm",        "HPM Verification",                                       andPs [has_icsr, has_ihpm],               T.repeatTillEnd . genHPM)
            , ("capinspect", "Xcheri Extension Capability Inspection Verification",    has_cheri,                                const $ T.repeatTillEnd genCHERIinspection)
            , ("caparith",   "Xcheri Extension Capability Arithmetic Verification",    has_cheri,                                const $ T.repeatTillEnd genCHERIarithmetic)
            , ("capmisc",    "Xcheri Extension Capability Miscellaneous Verification", has_cheri,                                const $ T.repeatTillEnd genCHERImisc)

--- a/src/RISCV/ArchDesc.hs
+++ b/src/RISCV/ArchDesc.hs
@@ -65,6 +65,7 @@ data ArchDesc = ArchDesc { has_xlen_32     :: Bool
                          , has_c           :: Bool
                          , has_n           :: Bool
                          , has_icsr        :: Bool
+                         , has_ihpm        :: Bool
                          , has_ifencei     :: Bool
                          , has_cheri       :: Bool
                          , has_nocloadtags :: Bool }
@@ -84,6 +85,7 @@ instance Show ArchDesc where
                 ++ ext has_c "c"
                 ++ ext has_n "n"
                 ++ intercalate "_" [ x | x <- [ ext has_icsr "Zicsr"
+                                              , ext has_ihpm "Zihpm"
                                               , ext has_ifencei "Zifencei"
                                               , ext has_cheri "Xcheri"
                                               , ext has_nocloadtags "Xnocloadtags" ]
@@ -102,6 +104,7 @@ archDesc_null  = ArchDesc { has_xlen_32     = False
                           , has_c           = False
                           , has_n           = False
                           , has_icsr        = False
+                          , has_ihpm        = False
                           , has_ifencei     = False
                           , has_cheri       = False
                           , has_nocloadtags = False
@@ -120,6 +123,7 @@ archDesc_rv32i = ArchDesc { has_xlen_32     = True
                           , has_c           = False
                           , has_n           = False
                           , has_icsr        = False
+                          , has_ihpm        = False
                           , has_ifencei     = False
                           , has_cheri       = False
                           , has_nocloadtags = False
@@ -139,6 +143,7 @@ fromString str = ArchDesc { has_xlen_32     = True
                           , has_c           = c
                           , has_n           = n
                           , has_icsr        = icsr
+                          , has_ihpm        = ihpm
                           , has_ifencei     = ifencei
                           , has_cheri       = cheri
                           , has_nocloadtags = nocloadtags
@@ -153,6 +158,7 @@ fromString str = ArchDesc { has_xlen_32     = True
         f = (head archStrings =~ "f") || (head archStrings =~ "g")
         d = (head archStrings =~ "d") || (head archStrings =~ "g")
         icsr = elem "icsr" archStrings || (head archStrings =~ "g")
+        ihpm = elem "ihpm" archStrings || (head archStrings =~ "g")
         ifencei = elem "ifencei" archStrings || (head archStrings =~ "g")
         c = head archStrings =~ "c"
         n = head archStrings =~ "n"


### PR DESCRIPTION
Otherwise we get lots of errors due to trapping on accesses to
mcountinhibit, etc.