### PR TITLE
Downgrade base requirement to 4.15

### DIFF
--- a/QCVEngine.cabal
+++ b/QCVEngine.cabal
@@ -57,7 +57,7 @@ executable QCVEngine
   other-extensions:    FlexibleInstances, MultiParamTypeClasses,
                        FunctionalDependencies, OverloadedStrings,
                        ScopedTypeVariables
-  build-depends:       base >=4.16, time, split >=0.2, regex-posix >=0.95,
+  build-depends:       base >=4.15, time, split >=0.2, regex-posix >=0.95,
                        binary >=0.8, bitwise >=1.0, network >=2.8, parsec,
                        bytestring >=0.10, filemanip >=0.3, splitmix >= 0.1.0.2,
                        basement >= 0.0.10, QuickCheck >= 2.12 && < 2.15,


### PR DESCRIPTION
On my system (Debian 12) `ghc --version` reports 9.0.2, so I don't have 4.16 yet. It seems to build just fine against 4.15, so downgrade the requirement to 4.15.

This was changed in 7aad5ed0c0dfc724226425e474e74b139f35a581