### PR TITLE
Respect --continue-on-failure for --trace-directory

### DIFF
--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -321,7 +321,7 @@ main = withSocketsDo $ do
                                                  readDataFile memInit
                               Nothing -> return mempty
                             res <- checkSingle (wrapTest $ initTrace <> trace) (optVerbosity flags) (optShrink flags) (testLen flags) (checkTrapAndSave (Just fileName))
-                            case res of Failure {} -> do putStrLn "Failure."
+                            case res of Failure {} -> do if optContinueOnFail flags then putStrLn "Failure." else error "Failure. Exiting..."
                                                          modifyIORef failuresRef ((+) 1)
                                         _          -> putStrLn "No Failure."
                             isAlive <- readIORef alive


### PR DESCRIPTION
Previously we were continuing unconditonally, now we abort the run on the first failure unless --continue-on-failure is passed. There is probably a way of doing this that doesn't print a backtrace, but this minimal change using `error` achives the desired semantics for me:
```
# Test end
QCVEngine: Failure. Exiting...
CallStack (from HasCallStack):
  error, called at src/QuickCheckVEngine/Main.hs:324:115 in main:Main
```

Fixes: https://github.com/CTSRD-CHERI/QuickCheckVEngine/issues/22