### PR TITLE
Add a bounded PCC template

### DIFF
--- a/src/QuickCheckVEngine/Templates/GenCHERI.hs
+++ b/src/QuickCheckVEngine/Templates/GenCHERI.hs
@@ -121,7 +121,8 @@ genRandomCHERITest arch = random $ do
                 , (10, cspecialRWChain)
                 , (10, randomCInvoke srcAddr srcData tmpReg tmpReg2)
                 , (10, makeShortCap)
-                , (10, clearASR tmpReg tmpReg2)
+                , (5, clearASR tmpReg tmpReg2)
+                , (5, boundPCC tmpReg tmpReg2 imm longImm)
                 , (20, inst $ cgettag dest dest)
                 , (if has_nocloadtags arch then 0 else 10, loadTags srcAddr srcData)
                 ]

--- a/src/QuickCheckVEngine/Templates/GenTransExec.hs
+++ b/src/QuickCheckVEngine/Templates/GenTransExec.hs
@@ -309,14 +309,14 @@ genJump :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Tem
 genJump memReg reg0 reg1 reg2 imm offset = random $ do
   let czero = 0
   let ra = 1
-  return $ instSeq [ cjalr ra reg1
-                   , cjalr czero ra
+  return $ instSeq [ jalr_cap ra reg1
+                   , jalr_cap czero ra
                    ]
 
 genCSCInst :: Integer -> Integer -> Integer -> Integer -> Template
 genCSCInst memReg reg0 reg1 reg2 = random $ do
   let czero = 0
-  return $ instDist [ (1, cjalr czero reg0)
+  return $ instDist [ (1, jalr_cap czero reg0)
                     , (2, add 29 29 29)
                     , (1, cload reg1 reg2 0x8)
                     , (1, auipc reg2 0)
@@ -344,7 +344,7 @@ gen_csc_inst_verify = random $ do
   let reg1 = 24
   let reg2 = 25
   let mtcc = 28
-  let startSeq = inst $ cjalr zeroReg startReg
+  let startSeq = inst $ jalr_cap zeroReg startReg
   let trainSeq = repeatN (18) (genJump memReg tmpReg pccReg loadReg 0x20 0x0)
   let leakSeq = repeatN (1) (genJump memReg2 tmpReg pccReg loadReg 0x20 0x100)
   let tortSeq = startSeq <> leakSeq

--- a/src/QuickCheckVEngine/Templates/Utils/CHERI.hs
+++ b/src/QuickCheckVEngine/Templates/Utils/CHERI.hs
@@ -34,6 +34,7 @@
 
 module QuickCheckVEngine.Templates.Utils.CHERI (
   randomCInvoke
+, boundPCC
 , clearASR
 , makeCap
 , makeCap_core
@@ -78,6 +79,15 @@ randomCInvoke cs1 cs2 typeReg tmpReg =
           , (1, mempty) ]
   <> instSeq [ cinvoke cs2 cs1
              , cmove 31 1 ]
+
+boundPCC :: Integer -> Integer -> Integer -> Integer -> Template
+boundPCC tmp1 tmp2 offset size =
+  mconcat [ inst $ cspecialrw tmp1 0 0, -- Get PCC
+            li64 tmp2 offset,
+            inst $ cincoffset tmp1 tmp1 tmp2, -- increment PCC
+            li64 tmp2 size,
+            inst $ csetbounds tmp1 tmp1 tmp2, -- reduce bounds
+            inst $ jalr_cap tmp1 tmp1 ] -- jump to new PCC
 
 clearASR :: Integer -> Integer -> Template
 clearASR tmp1 tmp2 = instSeq [ cspecialrw tmp1 0 0, -- Get PCC

--- a/src/QuickCheckVEngine/Templates/Utils/CHERI.hs
+++ b/src/QuickCheckVEngine/Templates/Utils/CHERI.hs
@@ -84,7 +84,7 @@ clearASR tmp1 tmp2 = instSeq [ cspecialrw tmp1 0 0, -- Get PCC
                                addi tmp2 0 0xbff, -- Load immediate without ASR set
                                candperm tmp1 tmp1 tmp2, -- Mask out ASR
                                cspecialrw 0 28 tmp1, -- Clear ASR in trap vector
-                               cjalr tmp1 0 ]
+                               jalr_cap tmp1 0 ]
 
 makeCap :: Integer -> Integer -> Integer -> Integer -> Integer -> Integer -> Template
 makeCap dst source tmp base len offset =
@@ -170,7 +170,7 @@ switchEncodingMode = random $ do
                    , addi tmpReg2 0 mode
                    , csetflags tmpReg1 tmpReg1 tmpReg2
                    , cspecialrw 0 28 tmpReg1 --Also write trap vector so we stay in cap mode
-                   , cjalr 0 tmpReg1 ]
+                   , jalr_cap 0 tmpReg1 ]
 
 cspecialRWChain :: Template
 cspecialRWChain = random $ do
@@ -181,7 +181,7 @@ cspecialRWChain = random $ do
   tmpReg5 <- src
   tmpReg6 <- src
   return $ instSeq [ cspecialrw tmpReg2 30 tmpReg1
-                   , cjalr      tmpReg2 0
+                   , jalr_cap      tmpReg2 0
                    , cspecialrw tmpReg4 30 tmpReg3
                    , cspecialrw tmpReg6 30 tmpReg5 ]
 

--- a/src/RISCV/RV32_Xcheri.hs
+++ b/src/RISCV/RV32_Xcheri.hs
@@ -87,7 +87,7 @@ module RISCV.RV32_Xcheri (
 , cfromptr
 , csub
 , cmove
-, cjalr
+, jalr_cap
 , cinvoke
 , ctestsubset
 , cspecialrw
@@ -196,8 +196,8 @@ cspecialrw cd cSP cs1              = encode cspecialrw_raw                      
 
 
 -- Control Flow
-cjalr_raw                          =                                        "1111111 01100 cs1[4:0] 000 cd[4:0] 1011011"
-cjalr cd cs1                       = encode cjalr_raw                                      cs1          cd
+jalr_cap_raw                       =                                        "1111111 01100 cs1[4:0] 000 cd[4:0] 1011011"
+jalr_cap cd cs1                    = encode jalr_cap_raw                                      cs1          cd
 cinvoke_raw                        =                                        "1111110 cs2[4:0] cs1[4:0] 000 00001 1011011"
 cinvoke cs2 cs1                    = encode cinvoke_raw                              cs2      cs1
 
@@ -357,7 +357,7 @@ rv32_xcheri_disass = [ cgetperm_raw                    --> prettyR_2op "cgetperm
                      , csub_raw                        --> prettyR "csub"
                      , cspecialrw_raw                  --> pretty_cspecialrw "cspecialrw"
                      , cmove_raw                       --> prettyR_2op "cmove"
-                     , cjalr_raw                       --> prettyR_2op "cjalr"
+                     , jalr_cap_raw                       --> prettyR_2op "jalr_cap"
                      , cinvoke_raw                     --> pretty_2src "cinvoke"
                      , ctestsubset_raw                 --> prettyR "ctestsubset"
                      , clear_raw                       --> pretty_reg_clear "clear"
@@ -419,7 +419,7 @@ rv32_xcheri_extract = [ cgetperm_raw                    --> extract_1op cgetperm
                       , csub_raw                        --> extract_2op csub_raw
                       , cspecialrw_raw                  --> extract_cspecialrw
                       , cmove_raw                       --> extract_cmove
-                      , cjalr_raw                       --> extract_1op cjalr_raw
+                      , jalr_cap_raw                       --> extract_1op jalr_cap_raw
                       , cinvoke_raw                     --> extract_cinvoke
                       , ctestsubset_raw                 --> extract_2op ctestsubset_raw
 --                    , clear_raw                       --> noextract -- TODO
@@ -535,7 +535,7 @@ rv32_xcheri_shrink = [ cgetperm_raw                    --> shrink_cgetperm
                      , csub_raw                        --> shrink_capcap
 --                   , cspecialrw_raw                  --> noshrink
                      , cmove_raw                       --> shrink_cmove
---                   , cjalr_raw                       --> noshrink
+--                   , jalr_cap_raw                       --> noshrink
                      , cinvoke_raw                     --> shrink_cinvoke
                      , ctestsubset_raw                 --> shrink_ctestsubset
 --                   , clear_raw                       --> noshrink
@@ -597,7 +597,7 @@ rv32_xcheri_misc src1 src2 srcScr imm dest =
 
 -- | List of cheri control instructions
 rv32_xcheri_control :: Integer -> Integer -> Integer -> [Instruction]
-rv32_xcheri_control src1 src2 dest = [ cjalr    dest src1
+rv32_xcheri_control src1 src2 dest = [ jalr_cap dest src1
                                      , cinvoke  src2 src1 ]
 
 -- | List of cheri memory instructions


### PR DESCRIPTION
This was helpful finding divergences for the removal of PCC relocation.
Without this change I was able to run thousands of caprandom rounds without
finding a divergence.