### PR TITLE
Fix verbose print of instrs that omit low imm bits

### DIFF
--- a/src/InstrCodec.hs
+++ b/src/InstrCodec.hs
@@ -122,9 +122,11 @@ subst :: Mapping -> BitList -> BitList
 subst m bs = unscatter [(bi, bs !! si) | (bi, si) <- m]
 
 -- Join a scattered bit-string, complain if gaps or overlapping
-unscatter :: [(Int, a)] -> [a]
-unscatter = join 0
+unscatter :: [(Int, Bool)] -> BitList
+unscatter m = zeros ++ join lsb m
   where
+   lsb = minimum [j | (j, _) <- m]
+   zeros = take lsb $ repeat False
    join _ [] = []
    join i m =
      case [x | (j, x) <- m, i == j] of


### PR DESCRIPTION
Modify `unscatter` so it works for instructions that do not encode the lowest bits of the immediate value provided to them. This issue has been hidden because many instructions have been encoded using the lower immediate bits rather than upper immediate bits (e.g. `imm[19:0]` rather than `imm[31:12]` for `lui`), and others (which do omit lower immediate bits) are not included in disassembly output (e.g. `c_lui` with empty `rv_c_disass`).

See also:
https://github.com/CTSRD-CHERI/QuickCheckVEngine/issues/41