### PR TITLE
Generate cmove in miscellaneous instructions

### DIFF
--- a/src/RISCV/RV32_Xcheri.hs
+++ b/src/RISCV/RV32_Xcheri.hs
@@ -596,6 +596,7 @@ rv32_xcheri_misc src1 src2 srcScr imm dest =
   , ccseal      dest src1 src2
   , csealentry  dest src1
   , ccleartag   dest src1
+  , cmove       dest src1
   , cspecialrw  dest srcScr src1 ]
 
 -- | List of cheri control instructions


### PR DESCRIPTION
Before this change the existing CHERI templates did not generate the CMOVE instruction at all.