### PR TITLE
Prevent shrink loops by keeping history when shrinking

### DIFF
--- a/QCVEngine.cabal
+++ b/QCVEngine.cabal
@@ -62,5 +62,5 @@ executable QCVEngine
                        bytestring >=0.10, filemanip >=0.3, splitmix >= 0.1.0.2,
                        basement >= 0.0.10, QuickCheck >= 2.12 && < 2.15,
                        regex-tdfa >= 1.3, pretty-diff >= 0.4,
-                       data-default >= 0.7, text >= 1.2
+                       data-default >= 0.7, text >= 1.2, containers >= 0.6.5.1
   default-language:    Haskell2010

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -304,7 +304,7 @@ main = withSocketsDo $ do
   alive <- newIORef True -- Cleared when either implementation times out, since they will may not be able to respond to future queries
   let checkSingle :: Test TestResult -> Int -> Bool -> Int -> (Test TestResult -> IO ()) -> IO Result
       checkSingle test verbosity doShrink len onFail = do
-        quickCheckWithResult (Args Nothing 1 1 len (verbosity > 0) (if doShrink then 1000 else 0))
+        quickCheckWithResult (Args Nothing 1 1 len (verbosity > 0) (if doShrink then 100000 else 0))
                              (prop implA m_implB alive onFail archDesc (timeoutDelay flags) verbosity Nothing (optIgnoreAsserts flags) (optStrict flags) (return test))
   let check_mcause_on_trap :: Test TestResult -> Test TestResult
       check_mcause_on_trap (trace :: Test TestResult) = if or (hasTrap <$> trace) then filterTest p trace <> wrapTest testSuffix else trace
@@ -348,7 +348,7 @@ main = withSocketsDo $ do
   let checkTrapAndSave sourceFile test = saveOnFail sourceFile test (check_mcause_on_trap :: Test TestResult -> Test TestResult)
   let checkResult = if verbosity > 1 then verboseCheckWithResult else quickCheckWithResult
   let checkGen gen remainingTests =
-        checkResult (Args Nothing remainingTests 1 (testLen flags) (verbosity > 0) (if optShrink flags then 1000 else 0))
+        checkResult (Args Nothing remainingTests 1 (testLen flags) (verbosity > 0) (if optShrink flags then 100000 else 0))
                     (prop implA m_implB alive (checkTrapAndSave Nothing) archDesc (timeoutDelay flags) verbosity (if (optSaveAll flags) then (saveDir flags) else Nothing) (optIgnoreAsserts flags) (optStrict flags) gen)
   failuresRef <- newIORef 0
   let checkFile (memoryInitFile :: Maybe FilePath) (skipped :: Int) (fileName :: FilePath)

--- a/src/QuickCheckVEngine/RVFI_DII/DII.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/DII.hs
@@ -95,7 +95,7 @@ data DII_Packet = DII_Packet { -- | the command (instruction/end packet)
                                -- | the timestamp
                              , dii_time :: DII_Time
                                -- | the instruction
-                             , dii_insn :: DII_Instruction }
+                             , dii_insn :: DII_Instruction } deriving (Eq, Ord)
 
 -- | A 'DII_Packet' is serialized to a 32-bit word with 8 bits of padding at
 --   the front

--- a/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
+++ b/src/QuickCheckVEngine/RVFI_DII/RVFI.hs
@@ -123,7 +123,7 @@ data RVFI_Packet = RVFI_Packet {
 -- Modelling of Virtual Memory
 -- Modelling of Atomic Memory Operations
 -- Skipping instructions
-}
+} deriving (Eq, Ord)
 
 rvfiGetFromString :: [Char] -> Maybe (RVFI_Packet -> Integer)
 rvfiGetFromString "valid"     = Just $ toInteger . rvfi_valid
@@ -157,7 +157,7 @@ data RVFI_IntData = RVFI_IntData {
 , rvfi_rs2_rdata :: {-# UNPACK #-} !RV_WordXLEN
 , rvfi_rd_addr   :: {-# UNPACK #-} !RV_RegIdx
 , rvfi_rd_wdata  :: {-# UNPACK #-} !RV_WordXLEN
-}
+} deriving (Eq, Ord)
 
 instance Show RVFI_IntData where
   show tok =  (printf
@@ -175,7 +175,7 @@ data RVFI_MemAccessData = RVFI_MemAccessData {
 , rvfi_mem_wmask :: {-# UNPACK #-} !Word32
 , rvfi_mem_rdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256
 , rvfi_mem_wdata :: {-# UNPACK #-} !Basement.Types.Word256.Word256
-}
+} deriving (Eq, Ord)
 
 hexStr :: BS.ByteString -> String
 hexStr msg = show (toLazyByteString (lazyByteStringHex msg))

--- a/src/QuickCheckVEngine/TestTypes.hs
+++ b/src/QuickCheckVEngine/TestTypes.hs
@@ -72,6 +72,21 @@ data Test t = TestEmpty
             | TestSequence (Test t) (Test t)
             | TestMeta (MetaInfo, Bool) (Test t)
 
+instance Eq t => Eq (Test t) where
+  TestEmpty == TestEmpty = True
+  TestSingle x == TestSingle y = x == y
+  TestSequence ax bx == TestSequence ay by = ax == ay && bx == by
+  TestMeta _ x == TestMeta _ y = x == y
+  _ == _ = False
+instance Ord t => Ord (Test t) where
+  TestMeta _ x <= TestMeta _ y = x <= y
+  TestEmpty <= _ = True
+  _ <= TestEmpty = False
+  TestSingle x <= TestSingle y = x <= y
+  TestSingle _ <= _ = True
+  _ <= TestSingle _ = False
+  TestSequence ax bx <= TestSequence ay by = ax <= ay || (ax == ay && bx <= by)
+
 instance Semigroup (Test t) where
   x <> y = TestSequence x y
 instance Monoid (Test t) where

--- a/src/RISCV/Helpers.hs
+++ b/src/RISCV/Helpers.hs
@@ -116,7 +116,7 @@ import RISCV.RV_CSRs
 import Data.Bits
 import InstrCodec (Instruction)
 
-data PrivMode = PRV_U | PRV_S | PRV_Reserved | PRV_M deriving (Enum, Show, Eq)
+data PrivMode = PRV_U | PRV_S | PRV_Reserved | PRV_M deriving (Enum, Show, Eq, Ord)
 privString :: Maybe PrivMode -> String
 privString Nothing = "PRV_?"
 privString (Just x) = show x


### PR DESCRIPTION
As well as preventing frustrating bugs, this will allow us to be a lot less conservative with our shrinking rules!