### PR TITLE
Switch from IORef to TempFile to track coverage stats

### DIFF
--- a/QCVEngine.cabal
+++ b/QCVEngine.cabal
@@ -66,5 +66,6 @@ executable QCVEngine
                        basement >= 0.0.10, QuickCheck >= 2.12 && < 2.15,
                        regex-tdfa >= 1.3, pretty-diff >= 0.4,
                        data-default >= 0.7, text >= 1.2, containers >= 0.6.5.1,
-                       table-layout >= 1.0
+                       table-layout >= 1.0, cereal >= 0.5.8.3, temporary >= 1.3,
+                       directory >= 1.3.8.5
   default-language:    Haskell2010

--- a/src/QuickCheckVEngine/Main.hs
+++ b/src/QuickCheckVEngine/Main.hs
@@ -48,6 +48,8 @@ import System.Exit
 import System.Environment
 import System.FilePath.Find
 import System.Console.GetOpt
+import System.IO.Temp
+import System.Directory
 import Data.IORef
 import Data.Maybe
 import Data.Time.Clock
@@ -56,6 +58,8 @@ import Control.Monad
 import Network.Socket
 import Test.QuickCheck
 import Text.Regex.TDFA
+import qualified Data.Serialize as Cereal
+import qualified Data.ByteString as BSStrict
 
 import RISCV hiding (or)
 import InstrCodec
@@ -309,11 +313,12 @@ main = withSocketsDo $ do
   instrSoc <- mapM (open "instruction-generator-port") addrInstr
   --
   alive <- newIORef True -- Cleared when either implementation times out, since they will may not be able to respond to future queries
-  stats <- newIORef emptyStats -- Updated with information on the instructions run throughout the tests
+  statsTmp <- emptySystemTempFile "StatsFile" -- Updated with information on the instructions run throughout the tests
+  BSStrict.writeFile statsTmp (Cereal.encode emptyStats)
   let checkSingle :: Test TestResult -> Int -> Bool -> Int -> (Test TestResult -> IO ()) -> IO Result
       checkSingle test verbosity doShrink len onFail = do
         quickCheckWithResult (Args Nothing 1 1 len (verbosity > 0) (if doShrink then 100000 else 0))
-                             (prop implA m_implB alive stats onFail archDesc (timeoutDelay flags) verbosity Nothing (optIgnoreAsserts flags) (optStrict flags) (return test))
+                             (prop implA m_implB alive statsTmp onFail archDesc (timeoutDelay flags) verbosity Nothing (optIgnoreAsserts flags) (optStrict flags) (return test))
   let check_mcause_on_trap :: Test TestResult -> Test TestResult
       check_mcause_on_trap (trace :: Test TestResult) = if or (hasTrap <$> trace) then filterTest p trace <> wrapTest testSuffix else trace
         where hasTrap (_, a, b) = maybe False rvfiIsTrap a || maybe False rvfiIsTrap b
@@ -349,7 +354,7 @@ main = withSocketsDo $ do
               putStrLn $ "Writing counterexample file to: " ++ fname
               writeFile fname (prelude ++ contents)
   let saveOnFail :: Maybe FilePath -> Test TestResult -> (Test TestResult -> Test TestResult) -> IO ()
-      saveOnFail sourceFile test testTrans = runImpls implA m_implB alive stats (timeoutDelay flags) 0 Nothing test onTrace onDeath onDeath
+      saveOnFail sourceFile test testTrans = runImpls implA m_implB alive statsTmp (timeoutDelay flags) 0 Nothing test onTrace onDeath onDeath
         where onDeath test = do putStrLn "Failure rerunning test"
                                 askAndSave sourceFile (show test) Nothing testTrans
               onTrace trace = askAndSave sourceFile (showAnnotatedTrace (isNothing m_implB) archDesc verbosity trace) (Just trace) testTrans
@@ -357,7 +362,7 @@ main = withSocketsDo $ do
   let checkResult = if verbosity > 1 then verboseCheckWithResult else quickCheckWithResult
   let checkGen gen remainingTests =
         checkResult (Args Nothing remainingTests 1 (testLen flags) (verbosity > 0) (if optShrink flags then 100000 else 0))
-                    (prop implA m_implB alive stats (checkTrapAndSave Nothing) archDesc (timeoutDelay flags) verbosity (if (optSaveAll flags) then (saveDir flags) else Nothing) (optIgnoreAsserts flags) (optStrict flags) gen)
+                    (prop implA m_implB alive statsTmp (checkTrapAndSave Nothing) archDesc (timeoutDelay flags) verbosity (if (optSaveAll flags) then (saveDir flags) else Nothing) (optIgnoreAsserts flags) (optStrict flags) gen)
   failuresRef <- newIORef 0
   let checkFile (memoryInitFile :: Maybe FilePath) (skipped :: Int) (fileName :: FilePath)
         | skipped == 0 = do putStrLn $ "Reading trace from " ++ fileName
@@ -405,12 +410,15 @@ main = withSocketsDo $ do
               doCheck (liftM (wrapTest . singleSeq . (MkInstruction <$>)) $ listOf (genInstrServer sock)) (nTests flags)
               return ()
   --
-  finalStats <- readIORef stats
-  writeFile (statsFile flags) (show finalStats)
-  when (verbosity > 1) $ putStrLn (show finalStats)
+  (finalStats :: Either String Stats) <- Cereal.decode <$> (BSStrict.readFile statsTmp)
+  let fs = case finalStats of Left err -> err
+                              Right s  -> show s
+  writeFile (statsFile flags) fs
+  when (verbosity > 1) $ putStrLn fs
   putStrLn $ "Written coverage stats to " ++ (statsFile flags)
   rvfiDiiClose implA
   maybe (pure ()) rvfiDiiClose m_implB
+  removeFile statsTmp
   --
   failures <- readIORef failuresRef
   if failures == 0 then exitSuccess else exitWith $ ExitFailure failures

--- a/src/QuickCheckVEngine/MainHelpers.hs
+++ b/src/QuickCheckVEngine/MainHelpers.hs
@@ -68,7 +68,9 @@ import Test.QuickCheck.Monadic
 import Control.Monad
 import Control.Exception (try, SomeException(..))
 import qualified Data.ByteString.Lazy as BS
+import qualified Data.ByteString as BSStrict
 import qualified Data.Set as Set
+import qualified Data.Serialize as Cereal
 
 import qualified InstrCodec
 import RISCV hiding (and, or)
@@ -156,7 +158,7 @@ wrapTest = (<> single (diiEnd, Nothing, Nothing))
 runImpls :: RvfiDiiConnection         -- ^ Implementation A connection
          -> Maybe RvfiDiiConnection   -- ^ Implementation B connection
          -> IORef Bool                -- ^ Implementations still alive?
-         -> IORef Stats               -- ^ Accumulated coverage statistics
+         -> FilePath                  -- ^ Path to accumulated coverage statistics
          -> Int                       -- ^ RVFI-DII delay
          -> Int                       -- ^ Verbosity
          -> Maybe FilePath            -- ^ Optional save directory for failed tests
@@ -165,11 +167,11 @@ runImpls :: RvfiDiiConnection         -- ^ Implementation A connection
          -> (Test DII_Packet -> IO a) -- ^ Callback: first implementation disconnect
          -> (Test DII_Packet -> IO a) -- ^ Callback: already disconnected implementations
          -> IO a
-runImpls connA m_connB alive stats delay verbosity saveDir test onTrace onFirstDeath onSubsequentDeaths = do
+runImpls connA m_connB alive statsTmp delay verbosity saveDir test onTrace onFirstDeath onSubsequentDeaths = do
   let instTrace = (\(x, _, _) -> x) <$> test
   currentlyAlive <- readIORef alive
   if currentlyAlive then do
-    m_trace <- doRVFIDII connA m_connB alive stats delay verbosity saveDir test
+    m_trace <- doRVFIDII connA m_connB alive statsTmp delay verbosity saveDir test
     case m_trace of
       Just trace -> onTrace trace
       _ -> onFirstDeath instTrace
@@ -188,7 +190,7 @@ instance Show TestWithSeen where
 prop :: RvfiDiiConnection             -- ^ Implementation A connection
      -> Maybe RvfiDiiConnection       -- ^ Implementation B connection
      -> IORef Bool                    -- ^ Implementations still alive?
-     -> IORef Stats                   -- ^ Accumulated coverage stats
+     -> FilePath                      -- ^ Path to accumulated coverage stats
      -> (Test TestResult -> IO ())    -- ^ Callback on falsification
      -> ArchDesc                      -- ^ Archictecture description
      -> Int                           -- ^ RVFI-DII Delay
@@ -198,13 +200,13 @@ prop :: RvfiDiiConnection             -- ^ Implementation A connection
      -> Bool                          -- ^ Strict RVFI response comparison
      -> Gen (Test TestResult)         -- ^ Test generator
      -> Property
-prop connA m_connB alive stats onFail arch delay verbosity saveDir ignoreAsserts strict gen =
+prop connA m_connB alive statsTmp onFail arch delay verbosity saveDir ignoreAsserts strict gen =
   forAllShrink genDedup shrinkTestDedup mkPropDedup
   where mkPropDedup t = mkProp (test t)
         genDedup = (\t -> MkTestWithSeen t (Set.singleton t)) <$> gen
         shrinkTestDedup t = map (\t' -> MkTestWithSeen t' (Set.insert t' (seen t))) (filter (flip Set.notMember (seen t)) (shrinkTest (test t)))
         mkProp test = whenFail (onFail test) (doProp test)
-        doProp test = monadicIO $ run $ runImpls connA m_connB alive stats delay verbosity saveDir test onTrace onFirstDeath onSubsequentDeaths
+        doProp test = monadicIO $ run $ runImpls connA m_connB alive statsTmp delay verbosity saveDir test onTrace onFirstDeath onSubsequentDeaths
         colourGreen = "\ESC[32m"
         colourRed = "\ESC[31m"
         colourEnd = "\ESC[0m"
@@ -235,13 +237,13 @@ prop connA m_connB alive stats onFail arch delay verbosity saveDir ignoreAsserts
 doRVFIDII :: RvfiDiiConnection        -- ^ Implementation A connection
           -> Maybe RvfiDiiConnection  -- ^ Implementation B connection
           -> IORef Bool               -- ^ Implementations still alive?
-          -> IORef Stats              -- ^ Coverage information
+          -> FilePath                 -- ^ Path to coverage information
           -> Int                      -- ^ RVFI-DII delay
           -> Int                      -- ^ Verbosity
           -> Maybe FilePath           -- ^ Optional save directory for failed tests
           -> Test TestResult          -- ^ Input instruction sequence
           -> IO (Maybe (Test TestResult))
-doRVFIDII connA m_connB alive stats delay verbosity saveDir test = do
+doRVFIDII connA m_connB alive statsTmp delay verbosity saveDir test = do
   let instTrace = (\(x, _, _) -> x) <$> test
   let insts = instTrace
   currentlyAlive <- readIORef alive
@@ -260,7 +262,12 @@ doRVFIDII connA m_connB alive stats delay verbosity saveDir test = do
                                       return res
       m_traceA <- receive "implementation A" insts connA
       let traceA = fromMaybe (emptyTrace insts) m_traceA
-      modifyIORef stats (statTrace (snd <$> traceA))
+      statsDecode <- Cereal.decode <$> BSStrict.readFile statsTmp
+      oldStats <- case statsDecode of
+                    Left err -> do putStrLn $ "Error decoding stats: " ++ err
+                                   return emptyStats
+                    Right s  -> return s
+      BSStrict.writeFile statsTmp (Cereal.encode (statTrace (snd <$> traceA) oldStats))
       m_traceAB <- maybe (return . Just $ emptyTrace traceA) (receive "implementation B" traceA) m_connB
       --
       when (isNothing m_traceA || isNothing m_traceAB) $ writeIORef alive False

--- a/src/QuickCheckVEngine/Stats.hs
+++ b/src/QuickCheckVEngine/Stats.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 --
 -- SPDX-License-Identifier: BSD-2-Clause
 --
@@ -49,8 +50,10 @@ import InstrCodec
 import QuickCheckVEngine.TestTypes
 import QuickCheckVEngine.RVFI_DII
 import Text.Layout.Table
+import Data.Serialize as Cereal
+import GHC.Generics
 
-data Stats = MkStats (Map String (Int, Int))
+data Stats = MkStats (Map String (Int, Int)) deriving Generic
 
 emptyStats = MkStats empty
 
@@ -72,3 +75,5 @@ instance Show Stats where
                            columnSpec =          [column expand left def def, numCol  , numCol]
                            sortRows = reverse . sortOn sortKey
                            sortKey (_, (a, b)) = a+b
+
+instance Serialize Stats


### PR DESCRIPTION
The IORef was leaking significant memory as it accumulated thunks between runs.